### PR TITLE
[tags] Add node, remove build_number, and change job_name to job

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ https://github.com/jenkinsci/datadog-plugin/compare/datadog-build-reporter-0.1.3
 
 ### Changes
 * [BUGFIX] Improved method of determining the Jenkins hostname
+* [IMPROVEMENT] Remove build_number tag from metrics and service checks
+* [IMPROVEMENT] Add node tag to events, metrics, and service checks
 
 # 0.1.3 / 09-04-2015
 ### Details

--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@ List of metrics:
 List of service checks:
 * Build status (jenkins.job.status)
 
+All events, metrics, and service checks include the following tags, if they are available:
+* job
+* node
+* result
+* branch
+
 ## Installation
 _This plugin requires [Jenkins 1.580.1](http://updates.jenkins-ci.org/download/war/1.580.1/jenkins.war) or newer._
 

--- a/src/main/java/org/datadog/jenkins/plugins/datadogbuildreporter/DatadogBuildListener.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadogbuildreporter/DatadogBuildListener.java
@@ -205,8 +205,10 @@ public class DatadogBuildListener extends RunListener<Run>
    */
   private JSONArray assembleTags(final JSONObject builddata) {
     JSONArray tags = new JSONArray();
-    tags.add("job_name:" + builddata.get("job"));
-    tags.add("build_number:" + builddata.get("number"));
+    tags.add("job:" + builddata.get("job"));
+    if ( builddata.get("node") != null ) {
+      tags.add("node:" + builddata.get("node"));
+    }
     if ( builddata.get("result") != null ) {
       tags.add("result:" + builddata.get("result"));
     }
@@ -356,16 +358,6 @@ public class DatadogBuildListener extends RunListener<Run>
     long timestamp = builddata.getLong("timestamp");
     String message = "";
 
-    // Assemble Tags
-    JSONArray tags = new JSONArray();
-    tags.add("job:" + builddata.get("job"));
-    if ( builddata.get("result") != null ) {
-      tags.add("result:" + builddata.get("result"));
-    }
-    if ( builddata.get("branch") != null ) {
-      tags.add("branch:" + builddata.get("branch"));
-    }
-
     // Setting source_type_name here, to allow modification based on type of event
     payload.put("source_type_name", "jenkins");
 
@@ -402,9 +394,8 @@ public class DatadogBuildListener extends RunListener<Run>
     payload.put("date_happened", timestamp);
     payload.put("event_type", builddata.get("event_type"));
     payload.put("host", hostname);
-    payload.put("number", number);
     payload.put("result", builddata.get("result"));
-    payload.put("tags", tags);
+    payload.put("tags", assembleTags(builddata));
     payload.put("aggregation_key", job); // Used for job name in event rollups
 
     post(payload, this.EVENT);


### PR DESCRIPTION
Having build_number added as a tag for every metric and event is causing too many contexts to be generated. Additionally, it's not even of much use.