### PR TITLE
Replacing PrintStream with java.util.Logging to make it less verbose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changes
 =======
 
+# 0.3.1 / 11-03-2015
+### Changes
+* [IMPROVEMENT] Replaced PrintStream with JUL so that logging verbosity can be better controlled based on what the actual user wants - delegates the responsibility to define log groups and levels to Jenkins.
+
 # 0.3.0 / 10-19-2015
 ### Details
 https://github.com/jenkinsci/datadog-plugin/compare/datadog-0.2.1...datadog-0.3.0

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
   <groupId>org.datadog.jenkins.plugins</groupId>
   <artifactId>datadog</artifactId>
-  <version>0.3.0-SNAPSHOT</version>
+  <version>0.3.1-SNAPSHOT</version>
   <packaging>hpi</packaging>
 
   <name>Datadog Plugin</name>

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogBuildListener.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogBuildListener.java
@@ -26,7 +26,6 @@ import java.io.DataOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.io.PrintStream;
 import java.net.HttpURLConnection;
 import java.net.Inet4Address;
 import java.net.UnknownHostException;
@@ -77,7 +76,7 @@ public class DatadogBuildListener extends RunListener<Run>
   static final float MINUTE = 60;
   static final float HOUR = 3600;
   static final Integer HTTP_FORBIDDEN = 403;
-  static private PrintStream logger = null;
+  private static final Logger logger =  Logger.getLogger(DatadogBuildListener.class.getName());
 
   /**
    * Runs when the {@link DatadogBuildListener} class is created.
@@ -93,21 +92,20 @@ public class DatadogBuildListener extends RunListener<Run>
    */
   @Override
   public final void onStarted(final Run run, final TaskListener listener) {
-    logger = listener.getLogger();
     String jobName = run.getParent().getDisplayName();
 
     // Process only if job is NOT in blacklist
     if ( isJobTracked(jobName) ) {
-      printLog("Started build!");
+      logger.fine("Started build!");
 
       // Grab environment variables
       EnvVars envVars = null;
       try {
         envVars = run.getEnvironment(listener);
       } catch (IOException e) {
-        printLog("ERROR: " + e.getMessage());
+        logger.severe(e.getMessage());
       } catch (InterruptedException e) {
-        printLog("ERROR: " + e.getMessage());
+        logger.severe(e.getMessage());
       }
 
       // Gather pre-build metadata
@@ -142,12 +140,11 @@ public class DatadogBuildListener extends RunListener<Run>
    */
   @Override
   public final void onCompleted(final Run run, @Nonnull final TaskListener listener) {
-    logger = listener.getLogger();
     final String jobName = run.getParent().getDisplayName();
 
     // Process only if job in NOT in blacklist
     if ( isJobTracked(jobName) ) {
-      printLog("Completed build!");
+      logger.fine("Completed build!");
 
       // Collect Data
       JSONObject builddata = gatherBuildMetadata(run, listener);
@@ -181,9 +178,9 @@ public class DatadogBuildListener extends RunListener<Run>
     try {
       envVars = run.getEnvironment(listener);
     } catch (IOException e) {
-      printLog("ERROR: " + e.getMessage());
+      logger.severe(e.getMessage());
     } catch (InterruptedException e) {
-      printLog("ERROR: " + e.getMessage());
+      logger.severe(e.getMessage());
     }
 
     // Assemble JSON
@@ -272,20 +269,20 @@ public class DatadogBuildListener extends RunListener<Run>
       rd.close();
       JSONObject json = (JSONObject) JSONSerializer.toJSON( result.toString() );
       if ( "ok".equals(json.getString("status")) ) {
-        printLog("API call of type '" + type + "' was sent successfully!");
-        printLog("Payload: " + payload.toString());
+        logger.finer(String.format("API call of type '%s' was sent successfully!", type));
+        logger.finer(String.format("Payload: %s", payload));
         return true;
       } else {
-        printLog("API call of type '" + type + "' failed!");
-        printLog("Payload: " + payload.toString());
+        logger.fine(String.format("API call of type '%s' failed!", type));
+        logger.fine(String.format("Payload: %s", payload));
         return false;
       }
     } catch (Exception e) {
       if ( conn.getResponseCode() == this.HTTP_FORBIDDEN ) {
-        printLog("Hmmm, your API key may be invalid. We received a 403 error.");
-        return false;
+        logger.severe("Hmmm, your API key may be invalid. We received a 403 error.");
+      } else {
+        logger.severe(String.format("Client error: %s", e));
       }
-      printLog("Client error: " + e);
       return false;
     } finally {
       if (conn != null) {
@@ -306,7 +303,7 @@ public class DatadogBuildListener extends RunListener<Run>
   public final void gauge(final String metricName, final JSONObject builddata,
                           final String key) {
     String builddataKey = nullSafeGetString(builddata, key);
-    printLog("Sending metric '" + metricName + "' with value " + builddataKey);
+    logger.fine(String.format("Sending metric '%s' with value %s", metricName, builddataKey));
 
     // Setup data point, of type [<unix_timestamp>, <value>]
     JSONArray points = new JSONArray();
@@ -343,7 +340,7 @@ public class DatadogBuildListener extends RunListener<Run>
    */
   public final void serviceCheck(final String checkName, final Integer status,
                                  final JSONObject builddata) {
-    printLog("Sending service check '" + checkName + "' with status " + status.toString());
+    logger.fine(String.format("Sending service check '%s' with status %s", checkName, status));
 
     // Build payload
     JSONObject payload = new JSONObject();
@@ -362,7 +359,7 @@ public class DatadogBuildListener extends RunListener<Run>
    * @param builddata - A JSONObject containing a builds metadata.
    */
   public final void event(final JSONObject builddata) {
-    printLog("Sending event");
+    logger.fine("Sending event");
 
     // Gather data
     JSONObject payload = new JSONObject();
@@ -377,23 +374,24 @@ public class DatadogBuildListener extends RunListener<Run>
     payload.put("source_type_name", "jenkins");
 
     // Build title
-    String title = job + " build #" + number;
+    StringBuilder title = new StringBuilder();
+    title.append(job).append(" build #").append(number);
     if ( "SUCCESS".equals( builddata.get("result") ) ) {
-      title = title + " succeeded";
+      title.append(" succeeded");
       payload.put("alert_type", "success");
       message = "%%% \n [See results for build #" + number + "](" + buildurl + ") ";
     } else if ( builddata.get("result") != null ) {
-      title = title + " failed";
+      title.append(" failed");
       payload.put("alert_type", "failure");
       message = "%%% \n [See results for build #" + number + "](" + buildurl + ") ";
     } else {
-      title = title + " started";
+      title.append(" started");
       payload.put("alert_type", "info");
       message = "%%% \n [Follow build #" + number + " progress](" + buildurl + ") ";
       // Remove source_type_name to keep started events from being rolled up
       payload.remove("source_type_name");
     }
-    title = title + " on " + hostname;
+    title.append(" on ").append(hostname);
 
     // Add duration
     if ( builddata.get("duration") != null ) {
@@ -404,7 +402,7 @@ public class DatadogBuildListener extends RunListener<Run>
     message = message + " \n %%%";
 
     // Build payload
-    payload.put("title", title);
+    payload.put("title", title.toString());
     payload.put("text", message);
     payload.put("date_happened", timestamp);
     payload.put("event_type", builddata.get("event_type"));
@@ -437,7 +435,7 @@ public class DatadogBuildListener extends RunListener<Run>
     // Check hostname configuration from Jenkins
     hostname = getDescriptor().getHostname();
     if ( (hostname != null) && isValidHostname(hostname) ) {
-      printLog("Using hostname set in 'Manage Plugins'. Hostname: " + hostname);
+      logger.fine(String.format("Using hostname set in 'Manage Plugins'. Hostname: %s", hostname));
       return hostname;
     }
 
@@ -446,8 +444,7 @@ public class DatadogBuildListener extends RunListener<Run>
       hostname = envVars.get("HOSTNAME").toString();
     }
     if ( (hostname != null) && isValidHostname(hostname) ) {
-      printLog("Using hostname found in $HOSTNAME host environment variable." +
-               " Hostname: " + hostname);
+      logger.fine(String.format("Using hostname found in $HOSTNAME host environment variable. Hostname: %s", hostname));
       return hostname;
     }
 
@@ -468,13 +465,12 @@ public class DatadogBuildListener extends RunListener<Run>
 
         hostname = out.toString();
       } catch (Exception e) {
-        printLog("ERROR: " + e.getMessage());
+        logger.severe(e.getMessage());
       }
 
       // Check hostname
       if ( (hostname != null) && isValidHostname(hostname) ) {
-        printLog("Using unix hostname found via `/bin/hostname -f`." +
-                 " Hostname: " + hostname);
+        logger.fine(String.format("Using unix hostname found via `/bin/hostname -f`. Hostname: %s", hostname));
         return hostname;
       }
     }
@@ -484,17 +480,16 @@ public class DatadogBuildListener extends RunListener<Run>
     try {
       hostname = Inet4Address.getLocalHost().getHostName().toString();
     } catch (UnknownHostException e) {
-      printLog("Unknown hostname error received for localhost. Error: " + e);
+      logger.fine(String.format("Unknown hostname error received for localhost. Error: %s", e));
     }
     if ( (hostname != null) && isValidHostname(hostname) ) {
-      printLog("Using hostname found via Inet4Address.getLocalHost().getHostName()." +
-               " Hostname: " + hostname);
+      logger.fine(String.format("Using hostname found via Inet4Address.getLocalHost().getHostName(). Hostname: %s", hostname));
       return hostname;
     }
 
     // Never found the hostname
     if ( (hostname == null) || "".equals(hostname) ) {
-      printLog("Unable to reliably determine host name. You can define one in " +
+      logger.warning("Unable to reliably determine host name. You can define one in " +
                "the 'Manage Plugins' section under the 'Datadog Plugin' section.");
     }
     return null;
@@ -515,14 +510,13 @@ public class DatadogBuildListener extends RunListener<Run>
 
     // Check if hostname is local
     if ( Arrays.asList(localHosts).contains(host) ) {
-      printLog("Hostname: " + hostname + " is local");
+      logger.fine(String.format("Hostname: %s is local", hostname));
       return false;
     }
 
     // Ensure proper length
     if ( hostname.length() > MAX_HOSTNAME_LEN ) {
-      printLog("Hostname: " + hostname + " is too long (max length is " + 
-               MAX_HOSTNAME_LEN.toString() + " characters)");
+      logger.fine(String.format("Hostname: %s is too long (max length is %s characters)", hostname, MAX_HOSTNAME_LEN));
       return false;
     }
 
@@ -554,16 +548,6 @@ public class DatadogBuildListener extends RunListener<Run>
     }
 
     return output;
-  }
-
-  /**
-   * Prints a message to the {@link PrintStream} logger.
-   *
-   * @param message - A String containing a message to be printed to the {@link PrintStream} logger.
-   */
-  public final static void printLog(final String message) {
-    final String prefix = "DatadogBuildListener.java: ";
-    logger.println(prefix + message);
   }
 
 

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogBuildListener.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogBuildListener.java
@@ -94,11 +94,10 @@ public class DatadogBuildListener extends RunListener<Run>
   @Override
   public final void onStarted(final Run run, final TaskListener listener) {
     logger = listener.getLogger();
-    String jobname = run.getParent().getDisplayName();
-    String[] blacklist = blacklistStringtoArray( getDescriptor().getBlacklist() );
+    String jobName = run.getParent().getDisplayName();
 
     // Process only if job is NOT in blacklist
-    if ( (blacklist == null) || !Arrays.asList(blacklist).contains(jobname.toLowerCase()) ) {
+    if ( isJobTracked(jobName) ) {
       printLog("Started build!");
 
       // Grab environment variables
@@ -114,7 +113,7 @@ public class DatadogBuildListener extends RunListener<Run>
       // Gather pre-build metadata
       JSONObject builddata = new JSONObject();
       builddata.put("hostname", getHostname(envVars)); // string
-      builddata.put("job", jobname); // string
+      builddata.put("job", jobName); // string
       builddata.put("number", run.number); // int
       builddata.put("result", null); // null
       builddata.put("duration", null); // null
@@ -129,6 +128,11 @@ public class DatadogBuildListener extends RunListener<Run>
     }
   }
 
+  private final boolean isJobTracked(final String jobName) {
+    final String[] blacklist = blacklistStringtoArray( getDescriptor().getBlacklist() );
+    return (blacklist == null) || !Arrays.asList(blacklist).contains(jobName.toLowerCase());
+  }
+
   /**
    * Called when a build is completed.
    *
@@ -139,11 +143,10 @@ public class DatadogBuildListener extends RunListener<Run>
   @Override
   public final void onCompleted(final Run run, @Nonnull final TaskListener listener) {
     logger = listener.getLogger();
-    String jobname = run.getParent().getDisplayName();
-    String[] blacklist = blacklistStringtoArray( getDescriptor().getBlacklist() );
+    final String jobName = run.getParent().getDisplayName();
 
     // Process only if job in NOT in blacklist
-    if ( (blacklist == null) || !Arrays.asList(blacklist).contains(jobname.toLowerCase()) ) {
+    if ( isJobTracked(jobName) ) {
       printLog("Completed build!");
 
       // Collect Data


### PR DESCRIPTION
In order to allow for more granular control over which messages are logged and where I'd like to propose that we replace PrintStream with jul which gives granular control from a Jenkins admin standpoint.

Please merge it if you are happy with that, otherwise please contact me so we can enhance it further.

Regards,
Daniel Alheiros