### PR TITLE
Add config setters

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,23 @@ Note: If you do not see the version of `Datadog Plugin` that you are expecting, 
 ## Configuration
 To configure your newly installed Datadog Plugin, simply navigate to the `Manage Jenkins -> Configure System` page on your Jenkins installation. Once there, scroll down to find the `Datadog Plugin` section. Find your API Key from the [API Keys](https://app.datadoghq.com/account/settings#api) page on your Datadog account, and copy/paste it into the `API Key` textbox on the Jenkins configuration screen. You can test that your API Key works by pressing the `Test Key` button, on the Jenkins configuration screen, directly below the API Key textbox. Once your configuration changes are finished, simply save them, and you're good to go!
 
+Alternatively, you have the option of configuring your Datadog plugin using a Groovy script like this one:
+
+```groovy
+import jenkins.model.*
+import org.datadog.jenkins.plugins.datadog.DatadogBuildListener
+
+def j = Jenkins.getInstance()
+def d = j.getDescriptor("org.datadog.jenkins.plugins.datadog.DatadogBuildListener")
+d.setHostname('https://your-jenkins.com:8080')
+d.setTagNode(true)
+d.setApiKey('XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
+d.setBlacklist('job1,job2')
+d.save()
+```
+
+Configuring the plugin this way might be useful if you're running your Jenkins Master in a Docker container using the [Official Jenkins Docker Image](https://github.com/jenkinsci/docker) or any derivative that supports plugins.txt and Groovy init scripts.
+
 ### Logging
 Logging is done by utilizing the java.util.Logger, which follows the [best logging practices for Jenkins](https://wiki.jenkins-ci.org/display/JENKINS/Logging). In order to obtain logs, follow the directions listed [here](https://wiki.jenkins-ci.org/display/JENKINS/Logging). When adding a Logger, all Datadog plugin functions start with `org.datadog.jenkins.plugins.datadog.` and the function name you're after should autopopulate. As of this writing, the only function available was `org.datadog.jenkins.plugins.datadog.DatadogBuildListener`.
 

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogBuildListener.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogBuildListener.java
@@ -826,12 +826,31 @@ public class DatadogBuildListener extends RunListener<Run>
     }
 
     /**
+     * Setter fuction for the {@link apiKey} global configuration.
+     *
+     * @param key = A string containing the plaintext representation of a
+     *     DataDog API Key
+     */
+    public void setApiKey(final String key) {
+      apiKey = Secret.fromString(fixEmptyAndTrim(key));
+    }
+
+    /**
      * Getter function for the {@link hostname} global configuration.
      *
      * @return a String containing the {@link hostname} global configuration.
      */
     public String getHostname() {
       return hostname;
+    }
+
+    /**
+     * Setter function for the {@link hostname} global configuration.
+     *
+     * @param host - A String containing the hostname of the Jenkins host.
+     */
+    public void setHostname(final String host) {
+      hostname = host;
     }
 
     /**
@@ -845,12 +864,37 @@ public class DatadogBuildListener extends RunListener<Run>
     }
 
     /**
+     * Setter function for the {@link blacklist} global configuration,
+     * accepting a comma-separated string of jobs that will be sanitized.
+     *
+     * @param jobs - a comma-separated list of jobs to blacklist from monitoring.
+     */
+    public void setBlacklist(final String jobs) {
+      // strip whitespace, remove duplicate commas, and make lowercase
+      blacklist = jobs
+        .replaceAll("\\s", "")
+        .replaceAll(",,", "")
+        .toLowerCase();
+    }
+
+    /**
      * Getter function for the optional tag {@link node} global configuration.
      *
-     * @return a Boolean containing optional tag value for the {@link node} global configuration.
+     * @return a Boolean containing optional tag value for the {@link node}
+     *     global configuration.
      */
     public Boolean getTagNode() {
       return tagNode;
+    }
+
+    /**
+     * Setter function for the optional tag {@link node} global configuration.
+     *
+     * @param willTag - A Boolean expressing whether the {@link node} tag will
+     *     be included.
+     */
+    public void setTagNode(final Boolean willTag) {
+      tagNode = willTag;
     }
   }
 }

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogBuildListener.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogBuildListener.java
@@ -795,20 +795,17 @@ public class DatadogBuildListener extends RunListener<Run>
     public boolean configure(final StaplerRequest req, final JSONObject formData)
            throws FormException {
       // Grab apiKey and hostname
-      apiKey = Secret.fromString(fixEmptyAndTrim(formData.getString("apiKey")));
-      hostname = formData.getString("hostname");
+      setApiKey(formData.getString("apiKey"));
+      setHostname(formData.getString("hostname"));
 
-      // Grab blacklist, strip whitespace, remove duplicate commas, and make lowercase
-      blacklist = formData.getString("blacklist")
-                          .replaceAll("\\s", "")
-                          .replaceAll(",,", "")
-                          .toLowerCase();
+      // Grab blacklist
+      setBlacklist(formData.getString("blacklist"));
 
       // Grab tagNode and coerse to a boolean
       if ( formData.getString("tagNode").equals("true") ) {
-        tagNode = true;
+        setTagNode(true);
       } else {
-        tagNode = false;
+        setTagNode(false);
       }
 
       // Persist global configuration information


### PR DESCRIPTION
I wanted a way to configure the plugin from a Groovy script. Having this would make allow me to create a Groovy init script for use with the official Jenkins Docker image.

The changes included in these commits will allow you to configure the plugin like so:

```groovy
import jenkins.model.*
import org.datadog.jenkins.plugins.datadog.DatadogBuildListener

def j = Jenkins.getInstance()
def d = j.getDescriptor("org.datadog.jenkins.plugins.datadog.DatadogBuildListener")
d.setHostname('https://foo.bar.com')
d.setTagNode(true)
d.setApiKey('abc123')
d.setBlacklist('job1,job2,,job3 , job4')
d.save()
```