### PR TITLE
fix off by one error when generating the list of tags

### DIFF
--- a/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogBuildListener.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogBuildListener.java
@@ -164,7 +164,7 @@ public class DatadogBuildListener extends RunListener<Run>
       // Tags after this point will be propertly formatted.
       JSONArray arr = evt.createPayload().getJSONArray("tags");
       String[] tagsToCounter = new String[arr.size()];
-      for(int i=0; i<arr.size()-1; i++) {
+      for(int i=0; i<arr.size(); i++) {
         tagsToCounter[i] = arr.getString(i);
       }
 


### PR DESCRIPTION
this is causing the jenkins.job.completed metric to always be missing a
tag at ~random
