### PR TITLE
Add whitelist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 Changes
 =======
 
+# 0.5.0 / 05-24-2016
+### Details
+https://github.com/jenkinsci/datadog-plugin/compare/datadog-0.4.1...datadog-0.5.0
+
+### Changes
+* [IMPROVEMENT] Adding tags by job, via job configuration screen or via workspace text file. See [#38](https://github.com/DataDog/jenkins-datadog-plugin/pull/38) (Thanks @MadsNielsen)
+* [IMPROVEMENT] Count metric for completed jobs. See [#39](https://github.com/DataDog/jenkins-datadog-plugin/pull/39) (Thanks @MadsNielsen)
+
 # 0.4.1 / 12-08-2015
 ### Details
 https://github.com/jenkinsci/datadog-plugin/compare/datadog-0.4.0...datadog-0.4.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changes
 =======
 
+# 0.5.2 / 06-23-2016
+### Details
+https://github.com/jenkinsci/datadog-plugin/compare/datadog-0.5.1...datadog-0.5.2
+
+### Changes
+* [BUGFIX] Catch and react to null property in DatadogUtilities.parseTagList(). See [84ec03](https://github.com/DataDog/jenkins-datadog-plugin/commit/84ec0385459928d6f408b7e2c0fe215555550da1)
+
 # 0.5.1 / 06-01-2016
 ### Details
 https://github.com/jenkinsci/datadog-plugin/compare/datadog-0.5.0...datadog-0.5.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changes
 =======
 
+# 0.5.3 / 07-12-2016
+### Details
+https://github.com/jenkinsci/datadog-plugin/compare/datadog-0.5.2...datadog-0.5.3
+
+### Changes
+* [BUGFIX] Reintroduce Jenkins source type for all events.
+
 # 0.5.2 / 06-23-2016
 ### Details
 https://github.com/jenkinsci/datadog-plugin/compare/datadog-0.5.1...datadog-0.5.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changes
 =======
 
+# 0.5.1 / 06-01-2016
+### Details
+https://github.com/jenkinsci/datadog-plugin/compare/datadog-0.5.0...datadog-0.5.1
+
+### Changes
+* [BUGFIX] Fixed an unhandled NPE caused when DataDog Job Properties were not selected. See [#44](https://github.com/DataDog/jenkins-datadog-plugin/pull/44) (Thanks @MadsNielsen)
+
 # 0.5.0 / 05-24-2016
 ### Details
 https://github.com/jenkinsci/datadog-plugin/compare/datadog-0.4.1...datadog-0.5.0

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ List of events:
 
 List of metrics:
 * Build duration, in seconds (jenkins.job.duration)
+* Jobs completed (jenkins.job.completed) - _Requires the Datadog Agent_
 
 List of service checks:
 * Build status (jenkins.job.status)
@@ -21,11 +22,18 @@ All events, metrics, and service checks include the following tags, if they are 
 * result
 * branch
 
-These are optional tags that can be included in all events, metrics, and service checks, if enabled from the `Manage Jenkins -> Configure System` page (disabled by default):
-* node
+Optional tags, included in events, metrics, and service checks. (Toggle from `Manage Jenkins -> Configure System`) 
+* node (disabled by default)
 
 ## Customization
-Currently we allow you the ability to blacklist any jobs which you do not want to have events, metrics, and service checks reported for.
+From the global configuration page, at `Manage Jenkins -> Configure System`.
+* Blacklisted Jobs
+	* A comma-separated list of job names that should not monitored. (eg: susans-job,johns-job,prod-release).
+
+From a job specific configuration page
+* Custom tags
+	* Added from a file in the job workspace, or
+	* Added as text directly from the configuration page
 
 ## Installation
 _This plugin requires [Jenkins 1.580.1](http://updates.jenkins-ci.org/download/war/1.580.1/jenkins.war) or newer._

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
   <groupId>org.datadog.jenkins.plugins</groupId>
   <artifactId>datadog</artifactId>
-  <version>0.5.1-SNAPSHOT</version>
+  <version>0.5.2-SNAPSHOT</version>
   <packaging>hpi</packaging>
 
   <name>Datadog Plugin</name>

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
   <groupId>org.datadog.jenkins.plugins</groupId>
   <artifactId>datadog</artifactId>
-  <version>0.5.2-SNAPSHOT</version>
+  <version>0.5.3-SNAPSHOT</version>
   <packaging>hpi</packaging>
 
   <name>Datadog Plugin</name>

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
   <groupId>org.datadog.jenkins.plugins</groupId>
   <artifactId>datadog</artifactId>
-  <version>0.5.0-SNAPSHOT</version>
+  <version>0.5.1-SNAPSHOT</version>
   <packaging>hpi</packaging>
 
   <name>Datadog Plugin</name>

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
   <groupId>org.datadog.jenkins.plugins</groupId>
   <artifactId>datadog</artifactId>
-  <version>0.5.3-SNAPSHOT</version>
+  <version>0.5.4-SNAPSHOT</version>
   <packaging>hpi</packaging>
 
   <name>Datadog Plugin</name>

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
   <groupId>org.datadog.jenkins.plugins</groupId>
   <artifactId>datadog</artifactId>
-  <version>0.4.1-SNAPSHOT</version>
+  <version>0.5.0-SNAPSHOT</version>
   <packaging>hpi</packaging>
 
   <name>Datadog Plugin</name>

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/BuildFinishedEventImpl.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/BuildFinishedEventImpl.java
@@ -59,6 +59,7 @@ public class BuildFinishedEventImpl implements DatadogEvent {
     payload.put("result", builddata.get("result"));
     payload.put("tags", DatadogUtilities.assembleTags(builddata, tags));
     payload.put("aggregation_key", job);
+    payload.put("source_type_name", "jenkins");
 
     return payload;
   }

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/BuildStartedEventImpl.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/BuildStartedEventImpl.java
@@ -59,6 +59,7 @@ public class BuildStartedEventImpl implements DatadogEvent  {
     payload.put("result", builddata.get("result"));
     payload.put("tags", DatadogUtilities.assembleTags(builddata, tags));
     payload.put("aggregation_key", job);
+    payload.put("source_type_name", "jenkins");
 
     return payload;
   }

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/CheckoutCompletedEventImpl.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/CheckoutCompletedEventImpl.java
@@ -59,6 +59,7 @@ public class CheckoutCompletedEventImpl implements DatadogEvent {
     payload.put("result", builddata.get("result"));
     payload.put("tags", DatadogUtilities.assembleTags(builddata, tags));
     payload.put("aggregation_key", job);
+    payload.put("source_type_name", "jenkins");
 
     return payload;
   }

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogBuildListener.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogBuildListener.java
@@ -579,9 +579,9 @@ public class DatadogBuildListener extends RunListener<Run>
     }
 
     /**
-     * Getter function for the optional tag {@link node} global configuration.
+     * Getter function for the optional tag {@link tagNode} global configuration.
      *
-     * @return a Boolean containing optional tag value for the {@link node} global configuration.
+     * @return a Boolean containing optional tag value for the {@link tagNode} global configuration.
      */
     public Boolean getTagNode() {
       return tagNode;

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogBuildListener.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogBuildListener.java
@@ -92,7 +92,7 @@ public class DatadogBuildListener extends RunListener<Run>
   public final void onStarted(final Run run, final TaskListener listener) {
     String jobName = run.getParent().getDisplayName();
     HashMap<String,String> tags = new HashMap<String,String>();
-    // Process only if job is NOT in blacklist
+    // Process only if job is NOT in blacklist and is in whitelist
     if ( DatadogUtilities.isJobTracked(jobName) ) {
       logger.fine("Started build! in onStarted()");
 
@@ -135,7 +135,7 @@ public class DatadogBuildListener extends RunListener<Run>
   @Override
   public final void onCompleted(final Run run, @Nonnull final TaskListener listener) {
     final String jobName = run.getParent().getDisplayName();
-    // Process only if job in NOT in blacklist
+    // Process only if job in NOT in blacklist and is in whitelist
     if ( DatadogUtilities.isJobTracked(jobName) ) {
       logger.fine("Completed build!");
 
@@ -359,6 +359,7 @@ public class DatadogBuildListener extends RunListener<Run>
     private Secret apiKey = null;
     private String hostname = null;
     private String blacklist = null;
+    private String whitelist = null;
     private Boolean tagNode = null;
     private String daemonHost = "localhost:8125";
     //The StatsDClient instance variable. This variable is leased by the RunLIstener
@@ -522,6 +523,12 @@ public class DatadogBuildListener extends RunListener<Run>
                           .replaceAll(",,", "")
                           .toLowerCase();
 
+      // Grab whitelist, strip whitespace, remove duplicate commas, and make lowercase
+      whitelist = formData.getString("whitelist")
+                          .replaceAll("\\s", "")
+                          .replaceAll(",,", "")
+                          .toLowerCase();
+
       // Grab tagNode and coerse to a boolean
       if ( formData.getString("tagNode").equals("true") ) {
         tagNode = true;
@@ -576,6 +583,17 @@ public class DatadogBuildListener extends RunListener<Run>
      */
     public String getBlacklist() {
       return blacklist;
+    }
+
+    /**
+     * Getter function for the {@link whitelist} global configuration, containing
+     * a comma-separated list of jobs to whitelist for monitoring. An empty or missing
+     * list means all jobs are whitelisted.
+     *
+     * @return a String array containing the {@link whitelist} global configuration.
+     */
+    public String getWhitelist() {
+      return whitelist;
     }
 
     /**

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogSCMListener.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogSCMListener.java
@@ -43,7 +43,7 @@ public class DatadogSCMListener extends SCMListener {
     String jobName = build.getParent().getDisplayName();
     HashMap<String,String> tags = new HashMap<String,String>();
     DatadogJobProperty prop = DatadogUtilities.retrieveProperty(build);
-    // Process only if job is NOT in blacklist
+    // Process only if job is NOT in blacklist and is in whitelist
     if ( DatadogUtilities.isJobTracked(jobName)
             && prop != null && prop.isEmitOnCheckout() ) {
       logger.fine("Checkout! in onCheckout()");

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogSCMListener.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogSCMListener.java
@@ -42,9 +42,10 @@ public class DatadogSCMListener extends SCMListener {
 
     String jobName = build.getParent().getDisplayName();
     HashMap<String,String> tags = new HashMap<String,String>();
+    DatadogJobProperty prop = DatadogUtilities.retrieveProperty(build);
     // Process only if job is NOT in blacklist
     if ( DatadogUtilities.isJobTracked(jobName)
-            && DatadogUtilities.retrieveProperty(build).isEmitOnCheckout() ) {
+            && prop != null && prop.isEmitOnCheckout() ) {
       logger.fine("Checkout! in onCheckout()");
 
       // Grab environment variables

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogUtilities.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogUtilities.java
@@ -14,6 +14,7 @@ import java.util.HashMap;
 import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 import jenkins.model.Jenkins;
 import net.sf.json.JSONArray;
@@ -138,6 +139,7 @@ public class DatadogUtilities {
    * @param r - Current build.
    * @return - The configured {@link DatadogJobProperty}. Null if not there
    */
+  @CheckForNull
   public static DatadogJobProperty retrieveProperty(Run r) {
     DatadogJobProperty property = (DatadogJobProperty)r.getParent()
             .getProperty(DatadogJobProperty.class);

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogUtilities.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogUtilities.java
@@ -102,6 +102,12 @@ public class DatadogUtilities {
     HashMap<String,String> map = new HashMap<String, String>();
 
     DatadogJobProperty property = DatadogUtilities.retrieveProperty(run);
+
+    // If Null, nothing to retrieve
+    if( property == null ) {
+      return map;
+    }
+
     String prop = property.getTagProperties();
 
     if( !property.isTagFileEmpty() ) {

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogUtilities.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogUtilities.java
@@ -57,22 +57,32 @@ public class DatadogUtilities {
   public static String getBlacklist() {
     return DatadogUtilities.getDatadogDescriptor().getBlacklist();
   }
+  /**
+   *
+   * @return - The list of included jobs configured in the global configuration. Shortcut method.
+   */
+  public static String getWhitelist() {
+    return DatadogUtilities.getDatadogDescriptor().getWhitelist();
+  }
 
   /**
-   * Checks if a jobName is blacklisted, or not.
+   * Checks if a jobName is blacklisted, whitelisted, or neither.
    *
    * @param jobName - A String containing the name of some job.
-   * @return a boolean to signify if the jobName is or is not blacklisted.
+   * @return a boolean to signify if the jobName is or is not blacklisted or whitelisted.
    */
   public static boolean isJobTracked(final String jobName) {
     final String[] blacklist = DatadogUtilities.blacklistStringtoArray(DatadogUtilities.getBlacklist() );
-    return (blacklist == null) || !Arrays.asList(blacklist).contains(jobName.toLowerCase());
+    final String[] whitelist = DatadogUtilities.whitelistStringtoArray(DatadogUtilities.getWhitelist() );
+    final String jobNameLowerCase = jobName.toLowerCase();
+    return ((blacklist == null) || !Arrays.asList(blacklist).contains(jobNameLowerCase) &&
+            (whitelist == null) || Arrays.asList(whitelist).contains(jobNameLowerCase));
   }
 
   /**
    * Converts a blacklist string into a String array.
    *
-   * @param blacklist - A String containing a set of key/value pairs.
+   * @param blacklist - A String containing a set of job names.
    * @return a String array representing the job names to be blacklisted. Returns
    *         empty string if blacklist is null.
    */
@@ -81,6 +91,16 @@ public class DatadogUtilities {
       return blacklist.split(",");
     }
     return ( new String[0] );
+  }
+  /**
+   * Converts a whitelist string into a String array.
+   *
+   * @param whitelist - A String containing a set of job names.
+   * @return a String array representing the job names to be whitelisted. Returns
+   *         empty string if whitelist is null.
+   */
+  private static String[] whitelistStringtoArray(final String whitelist) {
+    return blacklistStringtoArray(whitelist);
   }
 
   /**

--- a/src/main/resources/org/datadog/jenkins/plugins/datadog/DatadogBuildListener/global.jelly
+++ b/src/main/resources/org/datadog/jenkins/plugins/datadog/DatadogBuildListener/global.jelly
@@ -23,8 +23,12 @@
     <f:validateButton title="${%Test Hostname}" progress="${%Testing...}"
                       method="testHostname" with="hostname" />
     <f:entry title="Blacklisted Jobs"
-             description="A comma-separated list of job names that should not monitored. (eg: susans-job,johns-job,prod-release)." >
+             description="A comma-separated list of job names that should not monitored. (e.g.: susans-job,johns-job,prod-release)." >
       <f:textarea field="blacklist" optional="true" default="${blacklist}" />
+    </f:entry>
+    <f:entry title="Whitelisted Jobs"
+             description="A comma-separated list of job names that should be monitored. (e.g. susans-job,johns-job,prof-release). An empty whitelist permits all jobs." >
+      <f:textarea field="whitelist" optional="true" default="${whitelist}" />
     </f:entry>
     <f:entry title="Optional Tags"
              description="Name of node the current build is running on (i.e. 'master' for master node)." >


### PR DESCRIPTION
This commit adds a whitelist to the plugin to accompany the existing blacklist. If no whitelist is defined, then it has no effect. If it is defined, then the plugin only "tracks" jobs that are listed. If a job is listed in both the blacklist and whitelist, the blacklist wins (the job is not tracked).

I made this change because I found that the plugin picks up each module in a multi-module Maven build as a separate job. This caused the plugin to spam Datadog with lots of internal and (for me) unhelpful information. With the whitelist, I can target the top-level (actual) jobs only.
