### PR TITLE
Full names for jobs in folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ target/*
 nb-configuration.xml
 /datadog.iml
 /.idea/*
+.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ target/*
 .settings/
 /work/
 nb-configuration.xml
+/datadog.iml
+/.idea/*

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogBuildListener.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogBuildListener.java
@@ -89,10 +89,10 @@ public class DatadogBuildListener extends RunListener<Run>
    */
   @Override
   public final void onStarted(final Run run, final TaskListener listener) {
-    String jobName = run.getParent().getDisplayName();
+    String jobName = run.getParent().getFullDisplayName();
     HashMap<String,String> tags = new HashMap<String,String>();
     // Process only if job is NOT in blacklist
-    if ( DatadogUtilities.isJobTracked(run.getParent().getName()) ) {
+    if ( DatadogUtilities.isJobTracked(run.getParent().getFullDisplayName()) ) {
       logger.fine("Started build! in onStarted()");
 
       // Gather pre-build metadata
@@ -133,7 +133,7 @@ public class DatadogBuildListener extends RunListener<Run>
   @Override
   public final void onCompleted(final Run run, @Nonnull final TaskListener listener) {
     // Process only if job in NOT in blacklist
-    if ( DatadogUtilities.isJobTracked(run.getParent().getName()) ) {
+    if ( DatadogUtilities.isJobTracked(run.getParent().getFullDisplayName()) ) {
       logger.fine("Completed build!");
 
       // Collect Data

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogBuildListener.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogBuildListener.java
@@ -203,7 +203,7 @@ public class DatadogBuildListener extends RunListener<Run>
     builddata.put("timestamp", endtime); // long
     builddata.put("result", run.getResult().toString()); // string
     builddata.put("number", run.number); // int
-    builddata.put("job", run.getParent().getDisplayName()); // string
+    builddata.put("job", run.getParent().getFullDisplayName()); // string
 
     // Grab environment variables
     try {

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogSCMListener.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogSCMListener.java
@@ -40,7 +40,7 @@ public class DatadogSCMListener extends SCMListener {
   public void onCheckout(Run<?, ?> build, SCM scm, FilePath workspace, TaskListener listener,
           File changelogFile, SCMRevisionState pollingBaseline) throws Exception {
 
-    String jobName = build.getParent().getDisplayName();
+    String jobName = build.getParent().getFullDisplayName();
     HashMap<String,String> tags = new HashMap<String,String>();
     DatadogJobProperty prop = DatadogUtilities.retrieveProperty(build);
     // Process only if job is NOT in blacklist

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogSCMListener.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogSCMListener.java
@@ -44,7 +44,7 @@ public class DatadogSCMListener extends SCMListener {
     HashMap<String,String> tags = new HashMap<String,String>();
     DatadogJobProperty prop = DatadogUtilities.retrieveProperty(build);
     // Process only if job is NOT in blacklist
-    if ( DatadogUtilities.isJobTracked(build.getParent().getName())
+    if ( DatadogUtilities.isJobTracked(build.getParent().getFullDisplayName())
             && prop != null && prop.isEmitOnCheckout() ) {
       logger.fine("Checkout! in onCheckout()");
 


### PR DESCRIPTION
Fixes #35 

Resulting payloads to datadog, for a job named CD inside a folder named QA, are:

{"alert_type":"info","title":"QA » CD build #5100 started on jenkins","text":"%%% \n [Follow build #5100 progress](http://jenkins/job/QA/job/CD/5100/)  \n %%%","date_happened":1477376660,"host":"jenkins","tags":["job:QA » CD"],"aggregation_key":"QA » CD","source_type_name":"jenkins"}

{"event_type":"build result","alert_type":"success","title":"QA » CD build #5100 succeeded on jenkins","text":"%%% \n [See results for build #5100](http://jenkins/job/QA/job/CD/5100/) (2,91 mins) \n %%%","date_happened":1477376834,"host":"jenkins","result":"SUCCESS","tags":["job:QA » CD","result:SUCCESS"],"aggregation_key":"QA » CD","source_type_name":"jenkins"}

{"series":[{"metric":"jenkins.job.duration","points":[[1477376835,174.67600011825562]],"type":"gauge","host":"jenkins","tags":["job:QA » CD","result:SUCCESS"]}]}

{"check":"jenkins.job.status","host_name":"jenkins","timestamp":1477376835,"status":0,"tags":["job:QA » CD"]}
