### PR TITLE
Jenkins pipeline support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.DS_Store
 *.log
 target/*
 /target/

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
   <groupId>org.datadog.jenkins.plugins</groupId>
   <artifactId>datadog</artifactId>
-  <version>0.5.5-SNAPSHOT</version>
+  <version>0.5.6-SNAPSHOT</version>
   <packaging>hpi</packaging>
 
   <name>Datadog Plugin</name>
@@ -29,9 +29,9 @@
 
   <developers>
     <developer>
-      <id>datadog</id>
-      <name>Datadog</name>
-      <email>dev@datadoghq.com</email>
+      <id>davidartplus</id>
+      <name>David Guzman</name>
+      <email>davidartplus@gmail.com</email>
     </developer>
   </developers>
 
@@ -66,10 +66,25 @@
       <version>4.2.5</version>
     </dependency>
     <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-step-api</artifactId>
+      <version>2.2</version>
+    </dependency>
+    <dependency>
         <groupId>com.datadoghq</groupId>
         <artifactId>java-dogstatsd-client</artifactId>
         <version>2.1.1</version>
     </dependency>
+    <dependency>
+	  <groupId>org.apache.commons</groupId>
+	  <artifactId>commons-lang3</artifactId>
+	  <version>3.5</version>
+	</dependency>
+	<dependency>
+	  <groupId>joda-time</groupId>
+	  <artifactId>joda-time</artifactId>
+	  <version>2.9.6</version>
+	</dependency>
   </dependencies>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
   <groupId>org.datadog.jenkins.plugins</groupId>
   <artifactId>datadog</artifactId>
-  <version>0.5.6-SNAPSHOT</version>
+  <version>0.5.5-SNAPSHOT</version>
   <packaging>hpi</packaging>
 
   <name>Datadog Plugin</name>
@@ -29,9 +29,9 @@
 
   <developers>
     <developer>
-      <id>davidartplus</id>
-      <name>David Guzman</name>
-      <email>davidartplus@gmail.com</email>
+      <id>datadog</id>
+      <name>Datadog</name>
+      <email>dev@datadoghq.com</email>
     </developer>
   </developers>
 
@@ -71,20 +71,20 @@
       <version>2.2</version>
     </dependency>
     <dependency>
-        <groupId>com.datadoghq</groupId>
-        <artifactId>java-dogstatsd-client</artifactId>
-        <version>2.1.1</version>
+      <groupId>com.datadoghq</groupId>
+      <artifactId>java-dogstatsd-client</artifactId>
+      <version>2.1.1</version>
     </dependency>
     <dependency>
-	  <groupId>org.apache.commons</groupId>
-	  <artifactId>commons-lang3</artifactId>
-	  <version>3.5</version>
-	</dependency>
-	<dependency>
-	  <groupId>joda-time</groupId>
-	  <artifactId>joda-time</artifactId>
-	  <version>2.9.6</version>
-	</dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+      <version>3.5</version>
+    </dependency>
+    <dependency>
+      <groupId>joda-time</groupId>
+      <artifactId>joda-time</artifactId>
+      <version>2.9.6</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogBuildListener.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogBuildListener.java
@@ -149,7 +149,7 @@ public class DatadogBuildListener extends RunListener<Run>
 
       DatadogEvent evt = new BuildFinishedEventImpl(builddata, extraTags);
       DatadogHttpRequests.sendEvent(evt);
-      gauge("jenkins.job.duration", builddata, "duration", extraTags);
+      DatadogUtilities.gauge("jenkins.job.duration", builddata, "duration", extraTags);
       if ( "SUCCESS".equals(builddata.get("result")) ) {
         serviceCheck("jenkins.job.status", DatadogBuildListener.OK, builddata, extraTags);
       } else {
@@ -223,55 +223,6 @@ public class DatadogBuildListener extends RunListener<Run>
     }
 
     return builddata;
-  }
-
-
-  /**
-   * Sends a metric to the Datadog API, including the gauge name, and value.
-   *
-   * @param metricName - A String with the name of the metric to record.
-   * @param builddata - A JSONObject containing a builds metadata.
-   * @param key - A String with the name of the build metadata to be found in the {@link JSONObject}
-   *              builddata.
-   * @param extraTags - A list of tags, that are contributed via {@link DatadogJobProperty}.
-   */
-  public final void gauge(final String metricName, final JSONObject builddata,
-                          final String key, final HashMap<String,String> extraTags) {
-    String builddataKey = DatadogUtilities.nullSafeGetString(builddata, key);
-    logger.fine(String.format("Sending metric '%s' with value %s", metricName, builddataKey));
-
-    // Setup data point, of type [<unix_timestamp>, <value>]
-    JSONArray points = new JSONArray();
-    JSONArray point = new JSONArray();
-
-    long currentTime = System.currentTimeMillis() / DatadogBuildListener.THOUSAND_LONG;
-    point.add(currentTime); // current time, s
-    point.add(builddata.get(key));
-    points.add(point); // api expects a list of points
-
-    // Build metric
-    JSONObject metric = new JSONObject();
-    metric.put("metric", metricName);
-    metric.put("points", points);
-    metric.put("type", "gauge");
-    metric.put("host", builddata.get("hostname"));
-    metric.put("tags", DatadogUtilities.assembleTags(builddata, extraTags));
-
-    // Place metric as item of series list
-    JSONArray series = new JSONArray();
-    series.add(metric);
-
-    // Add series to payload
-    JSONObject payload = new JSONObject();
-    payload.put("series", series);
-
-    logger.fine(String.format("Resulting payload: %s", payload.toString() ));
-
-    try {
-      DatadogHttpRequests.post(payload, METRIC);
-    } catch (Exception e) {
-      logger.severe(e.toString());
-    }
   }
 
   /**

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogStep.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogStep.java
@@ -1,0 +1,157 @@
+package org.datadog.jenkins.plugins.datadog;
+
+import hudson.EnvVars;
+import hudson.Extension;
+import hudson.model.TaskListener;
+import hudson.model.Run;
+
+import java.io.IOException;
+import java.util.GregorianCalendar;
+import java.util.HashMap;
+import java.util.logging.Logger;
+
+import javax.annotation.Nonnull;
+
+import net.sf.json.JSONObject;
+
+import org.jenkinsci.plugins.workflow.steps.AbstractStepDescriptorImpl;
+import org.jenkinsci.plugins.workflow.steps.AbstractStepImpl;
+import org.jenkinsci.plugins.workflow.steps.AbstractSynchronousStepExecution;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+import com.google.inject.Inject;
+
+/**
+ * DatadogStep {@link AbstractStepImpl}.
+ *
+ * <p>When the user adds datadog step in Jenkinsfile,
+ * {@link DescriptorImpl} is invoked and a new
+ * {@link DatadogStep} is created.
+ *
+ * <p>When the step datadog is called, a job duration metric will be sent to datadog,
+ * using the configuration set in General Settings, by invoking {@link DatadogUtilities}.
+ *
+ * @author David Guzman
+ */
+
+public final class DatadogStep extends AbstractStepImpl{
+  
+  private static final Logger logger =  Logger.getLogger(DatadogStep.class.getName());
+  private HashMap<String, String> tags;
+	
+  /**
+   * Runs when the {@link DatadogStep} class is created.
+   * @param tags are the optional tags sent to datadog along with the metric value.
+   */
+  @DataBoundConstructor public DatadogStep(HashMap<String,String> tags) {
+    this.tags = tags;
+  }
+  
+  /**
+   * Tags passed in pipeline as parameters to the build step, i.e. datadog([key1:'Value1', tag2:'Value2']).
+   *
+   * @return a HashMap with tag values
+   */
+  public HashMap<String, String> getTags(){
+    return tags;
+  }
+  
+  /**
+   * Descriptor for {@link DatadogStep}. Used as a singleton.
+   * The class is marked as public so that it can be accessed from views.
+   */
+  @Extension
+  public static final class DescriptorImpl extends AbstractStepDescriptorImpl {
+  
+    /**
+     * Specifies the {@link Execution} for this DescriptorImpl
+     */
+    public DescriptorImpl() {
+      super(Execution.class);
+    }
+
+    /**
+     * Name used in pipeline script
+     */
+    @Override public String getFunctionName(){
+      return "datadog";
+    }
+    
+    /**
+     * Name used in Snippet Generator
+     */
+    @Override public String getDisplayName(){
+      return "Push job duration metric to Datadog";
+    }
+  }
+  
+  /**
+   * This Execution class performs actions for {@link DatadogStep}.
+   */
+  public static class Execution extends AbstractSynchronousStepExecution<String> {
+
+    /**
+     * Injects tags defined in {@link DatadogStep}
+     */
+    @Inject(optional=true) DatadogStep datadog;
+  
+    /**
+     * Runs the build step. It takes build information from {@link Run} and {@link TaskListener}.
+     * @return a String with the build data sent to datadog as a map.
+     * @throws Exception if data cannot be sent to datadog
+     */
+    @Override protected String run() throws Exception {
+      Run run = this.getContext().get(Run.class);
+      TaskListener listener = this.getContext().get(TaskListener.class);
+      JSONObject buildData = gatherRunningBuildMetadata(run, listener);
+  
+      try {
+        DatadogUtilities.gauge("jenkins.job.duration", buildData, "duration", datadog.getTags());
+        logger.fine("Executed step to send metric");
+      } catch (Exception e) {
+        logger.severe(e.toString());
+      }
+      return buildData.toString();
+    }
+  
+    /**
+     * Gathers unfinished build metadata, assembling it into a {@link JSONObject} before
+     * returning it to the caller.
+     *
+     * @param run - A Run object representing a particular execution of Job.
+     * @param listener - A TaskListener object which receives events that happen during some
+     *                   operation.
+     * @return a JSONObject containing a builds metadata.
+     */
+    private JSONObject gatherRunningBuildMetadata(@Nonnull final Run run, @Nonnull final TaskListener listener) {
+      // Assemble JSON
+      long scheduledstarttime = run.getStartTimeInMillis();
+      long timestamp = run.getTimeInMillis();
+      double duration = (new GregorianCalendar().getTimeInMillis()-timestamp) / DatadogBuildListener.THOUSAND_DOUBLE;
+      JSONObject builddata = new JSONObject();
+      builddata.put("starttime", scheduledstarttime); // long ms
+      builddata.put("timestamp", timestamp); // long ms
+      builddata.put("duration", duration); // double ms
+      builddata.put("number", run.number); // int
+      builddata.put("job", run.getParent().getDisplayName()); // string
+
+      // Grab environment variables
+      try {
+        EnvVars envVars = run.getEnvironment(listener);
+        builddata.put("hostname", DatadogUtilities.getHostname(envVars)); // string
+        builddata.put("buildurl", envVars.get("BUILD_URL")); // string
+        builddata.put("node", envVars.get("NODE_NAME")); // string
+        if ( envVars.get("GIT_BRANCH") != null ) {
+          builddata.put("branch", envVars.get("GIT_BRANCH")); // string
+        } else if ( envVars.get("CVS_BRANCH") != null ) {
+          builddata.put("branch", envVars.get("CVS_BRANCH")); // string
+        }
+      } catch (IOException e) {
+        logger.severe(e.getMessage());
+      } catch (InterruptedException e) {
+        logger.severe(e.getMessage());
+      }
+      return builddata;
+    }
+  } 
+}


### PR DESCRIPTION
Example:

```
node{
    stage "Test"
    sleep(1)
    builddata=datadog([color:'Blue', shape:'Circle'])
    println builddata
}
```
Console output, apart from the metric jenkins.job.duration being pushed to datadog:

```
Started by user admin
[Pipeline] node
Running on master in /var/jenkins_home/workspace/test-dd2-j5
[Pipeline] {
[Pipeline] stage (Test)
Using the ‘stage’ step without a block argument is deprecated
Entering stage Test
Proceeding
[Pipeline] sleep
Sleeping for 1 sec
[Pipeline] datadog
[Pipeline] echo
{"starttime":1480639557114,"timestamp":1480639557108,"duration":3.798,"number":10,"job":"test-dd2-j5","hostname":"94bb3c7e2202","buildurl":"http://localhost:8080/job/test-dd2-j5/10/"}
[Pipeline] }
[Pipeline] // node
[Pipeline] End of Pipeline
Finished: SUCCESS
```