### PR TITLE
Fix to StatsDClient reporting, logging

### DIFF
--- a/src/main/java/org/datadog/jenkins/plugins/datadog/BuildFinishedEventImpl.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/BuildFinishedEventImpl.java
@@ -12,9 +12,9 @@ public class BuildFinishedEventImpl implements DatadogEvent {
   private JSONObject builddata;
   private HashMap<String,String> tags;
 
-  public BuildFinishedEventImpl(JSONObject buildData, HashMap<String,String> tags)  {
+  public BuildFinishedEventImpl(JSONObject buildData, HashMap<String,String> buildTags)  {
     this.builddata = buildData;
-    this.tags = tags;
+    this.tags = buildTags;
   }
 
   //Creates the raw json payload for this event.

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogBuildListener.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogBuildListener.java
@@ -361,7 +361,7 @@ public class DatadogBuildListener extends RunListener<Run>
           logger.warning("StatsDClient is null");
         }
       } catch (Exception e) {
-        logger.severe(String.format("Error while configuring statsd client. Exception: %s", e.toString()));
+        logger.severe(String.format("Error while configuring StatsDClient. Exception: %s", e.toString()));
       }
       return client;
     }
@@ -569,7 +569,7 @@ public class DatadogBuildListener extends RunListener<Run>
           client = new NonBlockingStatsDClient("jenkins.job", hp, pp);
           logger.finer(String.format("Created new DogStatsD client (%s:%S)!", hp, pp));
         } catch (Exception e) {
-          logger.severe(String.format("Unable to create new DogstatsClient. Exception: %s", e.toString()));
+          logger.severe(String.format("Unable to create new StatsDClient. Exception: %s", e.toString()));
         }
       }
 

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogBuildListener.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogBuildListener.java
@@ -95,7 +95,7 @@ public class DatadogBuildListener extends RunListener<Run>
     HashMap<String,String> tags = new HashMap<String,String>();
     // Process only if job is NOT in blacklist
     if ( DatadogUtilities.isJobTracked(run.getParent().getName()) ) {
-      logger.fine("Started build! in onStarted()");
+      logger.fine("Started build!");
 
       // Gather pre-build metadata
       JSONObject builddata = new JSONObject();
@@ -121,6 +121,7 @@ public class DatadogBuildListener extends RunListener<Run>
       BuildStartedEventImpl evt = new BuildStartedEventImpl(builddata, tags);
 
       DatadogHttpRequests.sendEvent(evt);
+      logger.fine("Finished onStarted()");
     }
   }
 
@@ -191,6 +192,7 @@ public class DatadogBuildListener extends RunListener<Run>
       } else {
         logger.warning("Invalid dogstats daemon host specificed");
       }
+      logger.fine("Finished onCompleted()");
     }
   }
 

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogHttpRequests.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogHttpRequests.java
@@ -116,7 +116,7 @@ public class DatadogHttpRequests {
       if (conn.getResponseCode() == DatadogBuildListener.HTTP_FORBIDDEN) {
         logger.severe("Hmmm, your API key may be invalid. We received a 403 error.");
       } else {
-        logger.severe(String.format("Client error: %s", e));
+        logger.severe(String.format("Client error: %s", e.toString()));
       }
       return false;
     } finally {


### PR DESCRIPTION
Changes made to properly stop the StatsDClient after usage, in #73, appears to close the StatsDClient before it has a chance to actually report. I would have thought that it would report before closing, but it doesn't appear to do any sort of blocking on this at all, which also makes sense. Hence, I've added a short 100ms sleep, which again allows this metric to be reported.

I retested this confirming that the UDP sockets are released, and the metric is properly reported.

This also adds the `result` tag to the `jenkins.job.completed` metric.