### PR TITLE
Add whitelist configuration option

### DIFF
--- a/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogBuildListener.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogBuildListener.java
@@ -92,15 +92,16 @@ public class DatadogBuildListener extends RunListener<Run>
   @Override
   public final void onStarted(final Run run, final TaskListener listener) {
     String jobName = run.getParent().getFullDisplayName();
+    jobName = DatadogUtilities.normalizeFullDisplayName(jobName);
     HashMap<String,String> tags = new HashMap<String,String>();
 
-    // Process only if job is NOT in blacklist
-    if ( DatadogUtilities.isJobTracked(run.getParent().getFullDisplayName()) ) {
+    // Process only if job is NOT in blacklist and is in whitelist
+    if ( DatadogUtilities.isJobTracked(jobName) ) {
       logger.fine("Started build!");
 
       // Gather pre-build metadata
       JSONObject builddata = new JSONObject();
-      builddata.put("job", DatadogUtilities.normalizeFullDisplayName(jobName)); // string
+      builddata.put("job", jobName); // string
       builddata.put("number", run.number); // int
       builddata.put("result", null); // null
       builddata.put("duration", null); // null
@@ -136,8 +137,11 @@ public class DatadogBuildListener extends RunListener<Run>
 
   @Override
   public final void onCompleted(final Run run, @Nonnull final TaskListener listener) {
-    // Process only if job in NOT in blacklist
-    if ( DatadogUtilities.isJobTracked(run.getParent().getFullDisplayName()) ) {
+    String jobName = run.getParent().getFullDisplayName();
+    jobName = DatadogUtilities.normalizeFullDisplayName(jobName);
+
+    // Process only if job in NOT in blacklist and is in whitelist
+    if ( DatadogUtilities.isJobTracked(jobName) ) {
       logger.fine("Completed build!");
 
       // Collect Data
@@ -377,6 +381,7 @@ public class DatadogBuildListener extends RunListener<Run>
     private Secret apiKey = null;
     private String hostname = null;
     private String blacklist = null;
+    private String whitelist = null;
     private Boolean tagNode = null;
     private String daemonHost = "localhost:8125";
     private String targetMetricURL = "https://app.datadoghq.com/api/";
@@ -554,6 +559,12 @@ public class DatadogBuildListener extends RunListener<Run>
       // Grab blacklist
       this.setBlacklist(formData.getString("blacklist"));
 
+      // Grab whitelist, strip whitespace, remove duplicate commas, and make lowercase
+      whitelist = formData.getString("whitelist")
+                          .replaceAll("\\s", "")
+                          .replaceAll(",,", "")
+                          .toLowerCase();
+
       // Grab tagNode and coerse to a boolean
       if ( formData.getString("tagNode").equals("true") ) {
         this.setTagNode(true);
@@ -641,6 +652,30 @@ public class DatadogBuildListener extends RunListener<Run>
     public void setBlacklist(final String jobs) {
       // strip whitespace, remove duplicate commas, and make lowercase
       this.blacklist = jobs
+        .replaceAll("\\s", "")
+        .replaceAll(",,", "")
+        .toLowerCase();
+    }
+
+    /**
+     * Getter function for the {@link whitelist} global configuration, containing
+     * a comma-separated list of jobs to whitelist from monitoring.
+     *
+     * @return a String array containing the {@link whitelist} global configuration.
+     */
+    public String getWhitelist() {
+      return whitelist;
+    }
+
+    /**
+     * Setter function for the {@link whitelist} global configuration,
+     * accepting a comma-separated string of jobs that will be sanitized.
+     *
+     * @param jobs - a comma-separated list of jobs to whitelist from monitoring.
+     */
+    public void setWhitelist(final String jobs) {
+      // strip whitespace, remove duplicate commas, and make lowercase
+      this.whitelist = jobs
         .replaceAll("\\s", "")
         .replaceAll(",,", "")
         .toLowerCase();

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogSCMListener.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogSCMListener.java
@@ -41,10 +41,11 @@ public class DatadogSCMListener extends SCMListener {
           File changelogFile, SCMRevisionState pollingBaseline) throws Exception {
 
     String jobName = build.getParent().getFullDisplayName();
+    jobName = DatadogUtilities.normalizeFullDisplayName(jobName);
     HashMap<String,String> tags = new HashMap<String,String>();
     DatadogJobProperty prop = DatadogUtilities.retrieveProperty(build);
-    // Process only if job is NOT in blacklist
-    if ( DatadogUtilities.isJobTracked(build.getParent().getFullDisplayName())
+    // Process only if job is NOT in blacklist and is in whitelist
+    if ( DatadogUtilities.isJobTracked(jobName)
             && prop != null && prop.isEmitOnCheckout() ) {
       logger.fine("Checkout! in onCheckout()");
 
@@ -62,7 +63,7 @@ public class DatadogSCMListener extends SCMListener {
       // Gather pre-build metadata
       JSONObject builddata = new JSONObject();
       builddata.put("hostname", DatadogUtilities.getHostname(envVars)); // string
-      builddata.put("job", DatadogUtilities.normalizeFullDisplayName(jobName)); // string
+      builddata.put("job", jobName); // string
       builddata.put("number", build.number); // int
       builddata.put("result", null); // null
       builddata.put("duration", null); // null

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogUtilities.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogUtilities.java
@@ -78,6 +78,13 @@ public class DatadogUtilities {
   public static String getBlacklist() {
     return DatadogUtilities.getDatadogDescriptor().getBlacklist();
   }
+  /**
+   *
+   * @return - The list of included jobs configured in the global configuration. Shortcut method.
+   */
+  public static String getWhitelist() {
+    return DatadogUtilities.getDatadogDescriptor().getWhitelist();
+  }
 
   /**
    *
@@ -88,20 +95,23 @@ public class DatadogUtilities {
   }
 
   /**
-   * Checks if a jobName is blacklisted, or not.
+   * Checks if a jobName is blacklisted, whitelisted, or neither.
    *
    * @param jobName - A String containing the name of some job.
-   * @return a boolean to signify if the jobName is or is not blacklisted.
+   * @return a boolean to signify if the jobName is or is not blacklisted or whitelisted.
    */
   public static boolean isJobTracked(final String jobName) {
     final String[] blacklist = DatadogUtilities.blacklistStringtoArray(DatadogUtilities.getBlacklist() );
-    return (blacklist == null) || !Arrays.asList(blacklist).contains(jobName.toLowerCase());
+    final String[] whitelist = DatadogUtilities.whitelistStringtoArray(DatadogUtilities.getWhitelist() );
+    final String jobNameLowerCase = jobName.toLowerCase();
+    return ((blacklist == null) || !Arrays.asList(blacklist).contains(jobNameLowerCase) &&
+            (whitelist == null) || Arrays.asList(whitelist).contains(jobNameLowerCase));
   }
 
   /**
    * Converts a blacklist string into a String array.
    *
-   * @param blacklist - A String containing a set of key/value pairs.
+   * @param blacklist - A String containing a set of job names.
    * @return a String array representing the job names to be blacklisted. Returns
    *         empty string if blacklist is null.
    */
@@ -110,6 +120,16 @@ public class DatadogUtilities {
       return blacklist.split(",");
     }
     return ( new String[0] );
+  }
+  /**
+   * Converts a whitelist string into a String array.
+   *
+   * @param whitelist - A String containing a set of job names.
+   * @return a String array representing the job names to be whitelisted. Returns
+   *         empty string if whitelist is null.
+   */
+  private static String[] whitelistStringtoArray(final String whitelist) {
+    return blacklistStringtoArray(whitelist);
   }
 
   /**

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogUtilities.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogUtilities.java
@@ -101,35 +101,63 @@ public class DatadogUtilities {
    * @return a boolean to signify if the jobName is or is not blacklisted or whitelisted.
    */
   public static boolean isJobTracked(final String jobName) {
-    final String[] blacklist = DatadogUtilities.blacklistStringtoArray(DatadogUtilities.getBlacklist() );
-    final String[] whitelist = DatadogUtilities.whitelistStringtoArray(DatadogUtilities.getWhitelist() );
-    final String jobNameLowerCase = jobName.toLowerCase();
-    return ((blacklist == null) || !Arrays.asList(blacklist).contains(jobNameLowerCase) &&
-            (whitelist == null) || Arrays.asList(whitelist).contains(jobNameLowerCase));
+    if ( DatadogUtilities.isJobBlacklisted(jobName) ) {
+      return false;
+    }
+    return DatadogUtilities.isJobWhitelisted(jobName);
   }
 
   /**
-   * Converts a blacklist string into a String array.
+   * Checks if a jobName is blacklisted.
    *
-   * @param blacklist - A String containing a set of job names.
+   * @param jobName - A String containing the name of some job.
+   * @return a boolean to signify if the jobName is or is not blacklisted.
+   */
+  public static boolean isJobBlacklisted(final String jobName) {
+    final String[] blacklist = DatadogUtilities.joblistStringtoArray( DatadogUtilities.getBlacklist() );
+    final String jobNameLowerCase = jobName.toLowerCase();
+
+    if (blacklist != null) {
+      return Arrays.asList(blacklist).contains(jobNameLowerCase);
+    }
+
+    return false;
+  }
+
+  /**
+   * Checks if a jobName is whitelisted.
+   *
+   * @param jobName - A String containing the name of some job.
+   * @return a boolean to signify if the jobName is or is not whitelisted.
+   */
+  public static boolean isJobWhitelisted(final String jobName) {
+    final String[] whitelist = DatadogUtilities.joblistStringtoArray( DatadogUtilities.getWhitelist() );
+    final String jobNameLowerCase = jobName.toLowerCase();
+
+    if ( whitelist != null ) {
+      if ( whitelist.length == 0 ) {
+        return true;
+      }
+      return Arrays.asList(whitelist).contains(jobNameLowerCase);
+    }
+    return true;
+  }
+
+  /**
+   * Converts a blacklist/whitelist string into a String array.
+   *
+   * @param joblist - A String containing a set of job names.
    * @return a String array representing the job names to be blacklisted. Returns
    *         empty string if blacklist is null.
    */
-  private static String[] blacklistStringtoArray(final String blacklist) {
-    if ( blacklist != null ) {
-      return blacklist.split(",");
+  private static String[] joblistStringtoArray(final String joblist) {
+    if ( joblist != null ) {
+      String[] jobArr = joblist.split(",");
+      if ( jobArr[0] != "" ) {
+        return joblist.split(",");
+      }
     }
     return ( new String[0] );
-  }
-  /**
-   * Converts a whitelist string into a String array.
-   *
-   * @param whitelist - A String containing a set of job names.
-   * @return a String array representing the job names to be whitelisted. Returns
-   *         empty string if whitelist is null.
-   */
-  private static String[] whitelistStringtoArray(final String whitelist) {
-    return blacklistStringtoArray(whitelist);
   }
 
   /**

--- a/src/main/resources/org/datadog/jenkins/plugins/datadog/DatadogBuildListener/global.jelly
+++ b/src/main/resources/org/datadog/jenkins/plugins/datadog/DatadogBuildListener/global.jelly
@@ -24,7 +24,7 @@
     <f:validateButton title="${%Test Hostname}" progress="${%Testing...}"
                       method="testHostname" with="hostname" />
     <f:entry title="Blacklisted Jobs"
-             description="A comma-separated list of job names that should not monitored. (e.g.: susans-job,johns-job,prod-release)." >
+             description="A comma-separated list of job names that should not monitored. This takes precedent over whitelist. (e.g.: susans-job,johns-job,prod-release)." >
       <f:textarea field="blacklist" optional="true" default="${blacklist}" />
     </f:entry>
     <f:entry title="Whitelisted Jobs"

--- a/src/main/resources/org/datadog/jenkins/plugins/datadog/DatadogBuildListener/global.jelly
+++ b/src/main/resources/org/datadog/jenkins/plugins/datadog/DatadogBuildListener/global.jelly
@@ -24,8 +24,12 @@
     <f:validateButton title="${%Test Hostname}" progress="${%Testing...}"
                       method="testHostname" with="hostname" />
     <f:entry title="Blacklisted Jobs"
-             description="A comma-separated list of job names that should not monitored. (eg: susans-job,johns-job,prod-release)." >
+             description="A comma-separated list of job names that should not monitored. (e.g.: susans-job,johns-job,prod-release)." >
       <f:textarea field="blacklist" optional="true" default="${blacklist}" />
+    </f:entry>
+    <f:entry title="Whitelisted Jobs"
+             description="A comma-separated list of job names that should be monitored. (e.g. susans-job,johns-job,prof-release). An empty whitelist permits all jobs." >
+      <f:textarea field="whitelist" optional="true" default="${whitelist}" />
     </f:entry>
     <f:entry title="Optional Tags"
              description="Name of node the current build is running on (i.e. 'master' for master node)." >


### PR DESCRIPTION
This rebases @bhavanki's work in https://github.com/DataDog/jenkins-datadog-plugin/pull/56.

Note: Need to add a Changelog note about this being a potentially breaking change.

If you are currently using a blacklist, this may start working oddly if you are also using subfolders from the Workflow plugin. The top level job name was being used as the job tag before, and now it is the top level job followed by the subfolder names, separated by a forward slash. So jobs that had subfolders before, but were blacklisted, are going to suddenly appear.