### PR TITLE
Change space to underscore in normalizeFullDisplayName

### DIFF
--- a/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogUtilities.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogUtilities.java
@@ -433,7 +433,7 @@ public class DatadogUtilities {
    *         format usable as a tag.
    */
   public static String normalizeFullDisplayName(final String fullDisplayName) {
-    String normalizedName = fullDisplayName.replaceAll("»", "/").replaceAll(" ", "");
+    String normalizedName = fullDisplayName.replaceAll("»", "/").replaceAll(" ", "_");
     return normalizedName;
   }
 


### PR DESCRIPTION
A job name formatter was added In #77 that removed spaces from job name tags. The job name tags were previously sent with the space, and then converted in the Datadog backend to underscores. 

This PR changes the space to an underscore on the plugin side so tags do not change for jobs with spaces.