### PR TITLE
Set tagNode to false by default

### DIFF
--- a/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogBuildListener.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogBuildListener.java
@@ -393,7 +393,7 @@ public class DatadogBuildListener extends RunListener<Run>
     private Secret apiKey = null;
     private String hostname = null;
     private String blacklist = null;
-    private Boolean tagNode = null;
+    private Boolean tagNode = false;
     private String daemonHost = "localhost:8125";
     private String targetMetricURL = "https://app.datadoghq.com/api/";
     //The StatsDClient instance variable. This variable is leased by the RunLIstener


### PR DESCRIPTION
Fixes `NullPointerException` if the plugin is installed but not configured. We expect `SEVERE` logging because no API key is set, but we should avoid the NPE.

```
Apr 11, 2017 9:24:18 PM org.datadog.jenkins.plugins.datadog.DatadogHttpRequests post
SEVERE: Hmmm, your API key may be invalid. We received a 403 error.
Apr 11, 2017 9:24:18 PM hudson.model.Run execute
INFO: dummy job #41 main build action completed: SUCCESS
Apr 11, 2017 9:24:18 PM hudson.model.listeners.RunListener report
WARNING: RunListener failed
java.lang.NullPointerException
	at org.datadog.jenkins.plugins.datadog.DatadogUtilities.assembleTags(DatadogUtilities.java:383)
	at org.datadog.jenkins.plugins.datadog.DatadogBuildListener.onCompleted(DatadogBuildListener.java:154)
	at hudson.model.listeners.RunListener.fireCompleted(RunListener.java:211)
	at hudson.model.Run.execute(Run.java:1773)
	at hudson.model.FreeStyleBuild.run(FreeStyleBuild.java:43)
	at hudson.model.ResourceController.execute(ResourceController.java:98)
	at hudson.model.Executor.run(Executor.java:404)
```