### PR TITLE
Lower event priority for non-failure events

### DIFF
--- a/src/main/java/org/datadog/jenkins/plugins/datadog/BuildFinishedEventImpl.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/BuildFinishedEventImpl.java
@@ -36,6 +36,7 @@ public class BuildFinishedEventImpl implements DatadogEvent {
     if ("SUCCESS".equals(builddata.get("result"))) {
       title.append(" succeeded");
       payload.put("alert_type", "success");
+      payload.put("priority", "low");
       message = "%%% \n [See results for build #" + number + "](" + buildurl + ") ";
     } else if (builddata.get("result") != null) {
       title.append(" failed");

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/BuildStartedEventImpl.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/BuildStartedEventImpl.java
@@ -38,7 +38,6 @@ public class BuildStartedEventImpl implements DatadogEvent  {
     StringBuilder title = new StringBuilder();
     title.append(job).append(" build #").append(number);
     title.append(" started");
-    payload.put("alert_type", "info");
     message = "%%% \n [Follow build #" + number + " progress](" + buildurl + ") ";
 
     title.append(" on ").append(hostname);
@@ -51,6 +50,8 @@ public class BuildStartedEventImpl implements DatadogEvent  {
     message = message + " \n %%%";
 
     // Build payload
+    payload.put("alert_type", "info");
+    payload.put("priority", "low");
     payload.put("title", title.toString());
     payload.put("text", message);
     payload.put("date_happened", timestamp);

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/CheckoutCompletedEventImpl.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/CheckoutCompletedEventImpl.java
@@ -38,7 +38,6 @@ public class CheckoutCompletedEventImpl implements DatadogEvent {
     StringBuilder title = new StringBuilder();
     title.append(job).append(" build #").append(number);
     title.append(" checkout finished");
-    payload.put("alert_type", "info");
     message = "%%% \n [Follow build #" + number + " progress](" + buildurl + ") ";
 
     title.append(" on ").append(hostname);
@@ -51,6 +50,8 @@ public class CheckoutCompletedEventImpl implements DatadogEvent {
     message = message + " \n %%%";
 
     // Build payload
+    payload.put("alert_type", "info");
+    payload.put("priority", "low");
     payload.put("title", title.toString());
     payload.put("text", message);
     payload.put("date_happened", timestamp);


### PR DESCRIPTION
This PR sets all non-failure Jenkins events to `low` priority.

Lower non-failure priority levels was a customer request to reduce noise in the Event Stream.