### PR TITLE
remove oraclejdk7 from travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: java
+dist: trusty
 jdk:
 - oraclejdk8
 - openjdk7
+- openjdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: java
 jdk:
 - oraclejdk8
-- oraclejdk7
 - openjdk7


### PR DESCRIPTION
- Removes `oraclejdk7` from travis-ci, it is not longer supported. See: https://github.com/travis-ci/travis-ci/issues/7884#issuecomment-308451879
- Adds `openjdk8`
- Specifies the `trusty` distribution