### PR TITLE
Don't sanitize whitelist and blacklist

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Optional tags, included in events, metrics, and service checks. (Toggle from `Ma
 ## Customization
 From the global configuration page, at `Manage Jenkins -> Configure System`.
 * Blacklisted Jobs
-	* A comma-separated list of job names that should not monitored. (eg: susans-job,johns-job,prod-release).
+	* A comma-separated list of job names that should not monitored. (eg: susans-job,johns-job,prod_folder/prod_release).
 
 From a job specific configuration page
 * Custom tags

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogBuildListener.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogBuildListener.java
@@ -94,6 +94,7 @@ public class DatadogBuildListener extends RunListener<Run>
   @Override
   public final void onStarted(final Run run, final TaskListener listener) {
     String jobName = run.getParent().getFullName();
+    logger.fine(String.format("onStarted() called with jobName: %s", jobName));
     HashMap<String,String> tags = new HashMap<String,String>();
 
     // Process only if job is NOT in blacklist and is in whitelist
@@ -655,16 +656,12 @@ public class DatadogBuildListener extends RunListener<Run>
 
     /**
      * Setter function for the {@link blacklist} global configuration,
-     * accepting a comma-separated string of jobs that will be sanitized.
+     * accepting a comma-separated string of jobs.
      *
      * @param jobs - a comma-separated list of jobs to blacklist from monitoring.
      */
     public void setBlacklist(final String jobs) {
-      // strip whitespace, remove duplicate commas, and make lowercase
-      this.blacklist = jobs
-        .replaceAll("\\s", "")
-        .replaceAll(",,", "")
-        .toLowerCase();
+      this.blacklist = jobs;
     }
 
     /**
@@ -679,16 +676,12 @@ public class DatadogBuildListener extends RunListener<Run>
 
     /**
      * Setter function for the {@link whitelist} global configuration,
-     * accepting a comma-separated string of jobs that will be sanitized.
+     * accepting a comma-separated string of jobs.
      *
      * @param jobs - a comma-separated list of jobs to whitelist from monitoring.
      */
     public void setWhitelist(final String jobs) {
-      // strip whitespace, remove duplicate commas, and make lowercase
-      this.whitelist = jobs
-        .replaceAll("\\s", "")
-        .replaceAll(",,", "")
-        .toLowerCase();
+      this.whitelist = jobs;
     }
 
     /**

--- a/src/main/resources/org/datadog/jenkins/plugins/datadog/DatadogBuildListener/global.jelly
+++ b/src/main/resources/org/datadog/jenkins/plugins/datadog/DatadogBuildListener/global.jelly
@@ -24,11 +24,11 @@
     <f:validateButton title="${%Test Hostname}" progress="${%Testing...}"
                       method="testHostname" with="hostname" />
     <f:entry title="Blacklisted Jobs"
-             description="A comma-separated list of job names that should not monitored. This takes precedence over whitelist. (e.g.: susans-job,johns-job,prod-release)." >
+             description="A comma-separated list of job names that should not monitored. (e.g.: susans-job,johns-job,prod_folder/prod_release)." >
       <f:textarea field="blacklist" optional="true" default="${blacklist}" />
     </f:entry>
     <f:entry title="Whitelisted Jobs"
-             description="A comma-separated list of job names that should be monitored. (e.g.: susans-job,johns-job,prof-release). An empty whitelist permits all jobs." >
+             description="A comma-separated list of job names that should be monitored. (e.g.: susans-job,johns-job,prod_folder/prod_release). An empty whitelist permits all jobs not blacklisted." >
       <f:textarea field="whitelist" optional="true" default="${whitelist}" />
     </f:entry>
     <f:entry title="Optional Tags"


### PR DESCRIPTION
We shouldn't do any formatting to the whitelist and blacklist string entered in the config form. They are lowered and trimmed when we check jobs against the lists.