### PR TITLE
Add node tag to the jenkins.job.waiting

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
   <groupId>org.datadog.jenkins.plugins</groupId>
   <artifactId>datadog</artifactId>
-  <version>0.6.2-SNAPSHOT</version>
+  <version>0.6.3-SNAPSHOT</version>
   <packaging>hpi</packaging>
 
   <name>Datadog Plugin</name>

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogBuildListener.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogBuildListener.java
@@ -120,6 +120,7 @@ public class DatadogBuildListener extends RunListener<Run>
         tags = DatadogUtilities.parseTagList(run, listener);
         builddata.put("hostname", DatadogUtilities.getHostname(envVars)); // string
         builddata.put("buildurl", envVars.get("BUILD_URL")); // string
+        builddata.put("node", envVars.get("NODE_NAME")); // string
       } catch (IOException e) {
         logger.severe(e.getMessage());
       } catch (InterruptedException e) {


### PR DESCRIPTION
Added so the metric can be split in Datadog to show the wait time
per node