### PR TITLE
Set failed event to alert_type error

### DIFF
--- a/src/main/java/org/datadog/jenkins/plugins/datadog/BuildFinishedEventImpl.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/BuildFinishedEventImpl.java
@@ -40,7 +40,7 @@ public class BuildFinishedEventImpl implements DatadogEvent {
       message = "%%% \n [See results for build #" + number + "](" + buildurl + ") ";
     } else if (builddata.get("result") != null) {
       title.append(" failed");
-      payload.put("alert_type", "failure");
+      payload.put("alert_type", "error");
       message = "%%% \n [See results for build #" + number + "](" + buildurl + ") ";
     }
     title.append(" on ").append(hostname);


### PR DESCRIPTION
`alert_type` should be `error` not `failed` according to our [API documentation](https://docs.datadoghq.com/api/?lang=python#events).