### PR TITLE
Search path for hostname executable

### DIFF
--- a/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogBuildListener.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogBuildListener.java
@@ -383,7 +383,7 @@ public class DatadogBuildListener extends RunListener<Run>
    * Descriptor for {@link DatadogBuildListener}. Used as a singleton.
    * The class is marked as public so that it can be accessed from views.
    *
-   * <p>See <tt>DatadogBuildListener/*.jelly</tt> for the actual HTML fragment
+   * <p>See <code>DatadogBuildListener/*.jelly</code> for the actual HTML fragment
    * for the configuration screen.
    */
   @Extension // Indicates to Jenkins that this is an extension point implementation.

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogUtilities.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogUtilities.java
@@ -316,7 +316,7 @@ public class DatadogUtilities {
    * Tries, in order:
    *    Jenkins configuration
    *    Jenkins hostname environment variable
-   *    Unix hostname via `/bin/hostname -f`
+   *    Unix hostname via `/usr/bin/env hostname -f`
    *    Localhost hostname
    *
    * @param envVars - An EnvVars object containing a set of environment variables.
@@ -347,7 +347,7 @@ public class DatadogUtilities {
     if ( Arrays.asList(UNIX_OS).contains(os) ) {
       // Attempt to grab unix hostname
       try {
-        String[] cmd = {"/bin/hostname", "-f"};
+        String[] cmd = {"/usr/bin/env", "hostname", "-f"};
         Process proc = Runtime.getRuntime().exec(cmd);
         InputStream in = proc.getInputStream();
         BufferedReader reader = new BufferedReader(new InputStreamReader(in));
@@ -365,7 +365,7 @@ public class DatadogUtilities {
 
       // Check hostname
       if ( (hostname != null) && isValidHostname(hostname) ) {
-        logger.fine(String.format("Using unix hostname found via `/bin/hostname -f`. Hostname: %s",
+        logger.fine(String.format("Using unix hostname found via `/usr/bin/env hostname -f`. Hostname: %s",
                                   hostname));
         return hostname;
       }


### PR DESCRIPTION
The first tiny commit was added on the way to second tiny one. 

For context, without the change to the docs, when I ran `mvn package` I would get

```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-javadoc-plugin:2.10.1:javadoc (default) on project datadog: An error has occurred in JavaDocs report generation:
[ERROR] Exit code: 1 - /Users/shonfeder/oss/jenkins-plugins/datadog-plugin-jenkinsci/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogBuildListener.java:386: error: tag not supported in the generated HTML version: tt
[ERROR]    * <p>See <tt>DatadogBuildListener/*.jelly</tt> for the actual HTML fragment
```

We've tested to confirm that calling hostname via `/usr/bin/env` resolves the issue we were facing.