### PR TITLE
Added case for non-successful, non-failed builds

### DIFF
--- a/src/main/java/org/datadog/jenkins/plugins/datadog/BuildFinishedEventImpl.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/BuildFinishedEventImpl.java
@@ -36,12 +36,12 @@ public class BuildFinishedEventImpl implements DatadogEvent {
     // Build title
     StringBuilder title = new StringBuilder();
     title.append(job).append(" build #").append(number);
-    
-
-    message = "%%% \n [See results for build #" + number + "](" + buildurl + ") ";
-    title.append(" " + builddata.get("result").toString().toLowerCase());
 
     String buildResult = builddata.get("result") != null ? builddata.get("result").toString() : Result.NOT_BUILT.toString() ;
+
+    message = "%%% \n [See results for build #" + number + "](" + buildurl + ") ";
+    title.append(" " + buildResult.toLowerCase());
+
 
 
     if (Result.SUCCESS.toString().equals(buildResult)) {

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/BuildFinishedEventImpl.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/BuildFinishedEventImpl.java
@@ -38,8 +38,8 @@ public class BuildFinishedEventImpl implements DatadogEvent {
       payload.put("alert_type", "success");
       payload.put("priority", "low");
       message = "%%% \n [See results for build #" + number + "](" + buildurl + ") ";
-    } else if (builddata.get("result") == 'UNSTABLE' || builddata.get("result") == 'ABORTED' || builddata.get("result") == 'NOT_BUILT') {
-      title.append(" " + builddata.get("result").toLowerCase());
+    } else if ("UNSTABLE".equals(builddata.get("result"))  || "ABORTED".equals(builddata.get("result")) || "NOT_BUILT".equals(builddata.get("result"))) {
+      title.append(" " + builddata.get("result").toString().toLowerCase());
       payload.put("alert_type", "warning");
       message = "%%% \n [See results for build #" + number + "](" + buildurl + ") ";
     } else if (builddata.get("result") != null) {

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/BuildFinishedEventImpl.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/BuildFinishedEventImpl.java
@@ -1,6 +1,9 @@
 package org.datadog.jenkins.plugins.datadog;
 
 import java.util.HashMap;
+
+import hudson.model.Hudson;
+import hudson.model.Result;
 import net.sf.json.JSONObject;
 
 /**
@@ -33,20 +36,23 @@ public class BuildFinishedEventImpl implements DatadogEvent {
     // Build title
     StringBuilder title = new StringBuilder();
     title.append(job).append(" build #").append(number);
-    if ("SUCCESS".equals(builddata.get("result"))) {
-      title.append(" succeeded");
+    
+
+    message = "%%% \n [See results for build #" + number + "](" + buildurl + ") ";
+    title.append(" " + builddata.get("result").toString().toLowerCase());
+
+    String buildResult = builddata.get("result") != null ? builddata.get("result").toString() : Result.NOT_BUILT.toString() ;
+
+
+    if (Result.SUCCESS.toString().equals(buildResult)) {
       payload.put("alert_type", "success");
       payload.put("priority", "low");
-      message = "%%% \n [See results for build #" + number + "](" + buildurl + ") ";
-    } else if ("UNSTABLE".equals(builddata.get("result"))  || "ABORTED".equals(builddata.get("result")) || "NOT_BUILT".equals(builddata.get("result"))) {
-      title.append(" " + builddata.get("result").toString().toLowerCase());
+    } else if (Result.UNSTABLE.toString().equals(buildResult)  || Result.ABORTED.toString().equals(buildResult) || Result.NOT_BUILT.toString().equals(buildResult) ) {
       payload.put("alert_type", "warning");
-      message = "%%% \n [See results for build #" + number + "](" + buildurl + ") ";
-    } else if (builddata.get("result") != null) {
-      title.append(" failed");
+    } else if (Result.FAILURE.toString().equals(buildResult)) {
       payload.put("alert_type", "error");
-      message = "%%% \n [See results for build #" + number + "](" + buildurl + ") ";
     }
+    
     title.append(" on ").append(hostname);
     // Add duration
     if (builddata.get("duration") != null) {

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/BuildFinishedEventImpl.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/BuildFinishedEventImpl.java
@@ -38,6 +38,10 @@ public class BuildFinishedEventImpl implements DatadogEvent {
       payload.put("alert_type", "success");
       payload.put("priority", "low");
       message = "%%% \n [See results for build #" + number + "](" + buildurl + ") ";
+    } else if (builddata.get("result") == 'UNSTABLE' || builddata.get("result") == 'ABORTED' || builddata.get("result") == 'NOT_BUILT') {
+      title.append(" " + builddata.get("result").toLowerCase());
+      payload.put("alert_type", "warning");
+      message = "%%% \n [See results for build #" + number + "](" + buildurl + ") ";
     } else if (builddata.get("result") != null) {
       title.append(" failed");
       payload.put("alert_type", "error");


### PR DESCRIPTION
Marking as warning rather than failure for build not successful, but not failed.

if ABORTED, UNSTABLE, or NOT_BUILT [jenkins spec](https://javadoc.jenkins-ci.org/hudson/model/Result.html), set as status = warning and pass the correct build result in the title.

#139 