### PR TITLE
To make this plugin supporting Jenkinsfile

### DIFF
--- a/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogBuildStep.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogBuildStep.java
@@ -1,0 +1,49 @@
+package org.datadog.jenkins.plugins.datadog;
+
+import hudson.Extension;
+import hudson.FilePath;
+import hudson.Launcher;
+import hudson.model.*;
+import hudson.tasks.*;
+import jenkins.tasks.SimpleBuildStep;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+import javax.annotation.Nonnull;
+import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class DatadogBuildStep extends Builder implements SimpleBuildStep {
+    public static Map<String,String> tagPool = new ConcurrentHashMap<>();
+    private final String tags;
+
+    @DataBoundConstructor
+    public DatadogBuildStep(String tags) {
+        this.tags = tags;
+    }
+
+    public String getTags() {
+        return tags;
+    }
+
+    @Override
+    public void perform(@Nonnull Run<?, ?> run, @Nonnull FilePath workspace, @Nonnull Launcher launcher,
+                        @Nonnull TaskListener listener) throws InterruptedException, IOException {
+        String jobName = run.getParent().getFullName();
+        tagPool.put(jobName, tags);
+    }
+
+    @Extension
+    public static final class DescriptorImpl extends BuildStepDescriptor<Builder> {
+        public DescriptorImpl() {
+        }
+
+        public boolean isApplicable(Class<? extends AbstractProject> jobType) {
+            return true;
+        }
+
+        public String getDisplayName() {
+            return "DataDog Tagging";
+        }
+    }
+}

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogUtilities.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogUtilities.java
@@ -275,6 +275,21 @@ public class DatadogUtilities {
       }
     }
 
+    String jobName = run.getParent().getFullName();
+    if( DatadogBuildStep.tagPool.containsKey(jobName)) {
+      String tags = DatadogBuildStep.tagPool.get(jobName);
+      DatadogBuildStep.tagPool.remove(jobName);
+      for(String tag : tags.split(" ")) {
+        String[] expanded = run.getEnvironment(listener).expand(tag).split("=");
+        if( expanded.length > 1 ) {
+          map.put(expanded[0], expanded[1]);
+          logger.fine(String.format("Emitted tag %s:%s", expanded[0], expanded[1]));
+        } else {
+          logger.fine(String.format("Ignoring the tag %s. It is empty.", tag));
+        }
+      }
+    }
+
     return map;
   }
 

--- a/src/main/resources/org/datadog/jenkins/plugins/datadog/DatadogBuildStep/config.jelly
+++ b/src/main/resources/org/datadog/jenkins/plugins/datadog/DatadogBuildStep/config.jelly
@@ -1,0 +1,6 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+    <f:entry title="Tags" field="tags">
+        <f:textbox/>
+    </f:entry>
+</j:jelly>

--- a/src/main/resources/org/datadog/jenkins/plugins/datadog/DatadogJobProperty/config.jelly
+++ b/src/main/resources/org/datadog/jenkins/plugins/datadog/DatadogJobProperty/config.jelly
@@ -3,7 +3,7 @@
     <f:section title="Datadog Tagging">
         <f:optionalBlock name="enableFile" checked="${!instance.isTagFileEmpty()}" title="Add tags from file in workspace" inline="true">
             <f:entry title="File" field="tagFile">
-                <f:textbox/>
+                <f:textbox value="datadog.tags"/>
             </f:entry>
             <f:entry title="Send extra event after each successful checkout" field="emitOnCheckout"
 description="Note: Tags set this way, in the workspace, won't appear in started events.


### PR DESCRIPTION
# Changelog
* Declare and Assume a default tag file "datadog.tags" in the workspace - Not working for pipeline
* Support the pipeline of Jenkins

# Pipeline Usage
```
node {
   step([$class: 'DatadogBuildStep', tags: 'tag1=value1 tag2=value2 tag3=value3'])
}
```
> Note: This must appear in Jenfilefile once, otherwise, the other ones behind will override the ones before