### PR TITLE
Run if apiKey is configured

### DIFF
--- a/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogBuildListener.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogBuildListener.java
@@ -94,6 +94,9 @@ public class DatadogBuildListener extends RunListener<Run>
    */
   @Override
   public final void onStarted(final Run run, final TaskListener listener) {
+    if ( DatadogUtilities.isApiKeyNull() ) {
+      return;
+    }
     String jobName = run.getParent().getFullName();
     logger.fine(String.format("onStarted() called with jobName: %s", jobName));
     Map<String,String> tags = new HashMap<String,String>();
@@ -158,6 +161,9 @@ public class DatadogBuildListener extends RunListener<Run>
 
   @Override
   public final void onCompleted(final Run run, @Nonnull final TaskListener listener) {
+    if ( DatadogUtilities.isApiKeyNull() ) {
+      return;
+    }
     String jobName = run.getParent().getFullName();
 
     // Process only if job in NOT in blacklist and is in whitelist

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogHttpRequests.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogHttpRequests.java
@@ -1,6 +1,7 @@
 package org.datadog.jenkins.plugins.datadog;
 
 import hudson.ProxyConfiguration;
+import hudson.util.Secret;
 import java.io.BufferedReader;
 import java.io.DataOutputStream;
 import java.io.IOException;
@@ -81,7 +82,7 @@ public class DatadogHttpRequests {
    * @throws IOException if HttpURLConnection fails to open connection
    */
   public static Boolean post(final JSONObject payload, final String type) throws IOException {
-    String urlParameters = "?api_key=" + DatadogUtilities.getApiKey().getPlainText();
+    String urlParameters = "?api_key=" + Secret.toString(DatadogUtilities.getApiKey());
     HttpURLConnection conn = null;
     try {
       logger.finer("Setting up HttpURLConnection...");

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogQueueListener.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogQueueListener.java
@@ -29,6 +29,9 @@ public class DatadogQueueListener extends PeriodicWork {
 
   @Override
   protected void doRun() throws Exception {
+    if ( DatadogUtilities.isApiKeyNull() ) {
+      return;
+    }
     logger.fine("doRun called: Computing queue metrics");
     gauge("jenkins.queue.size", queue.getApproximateItemsQuickly().size());
   }

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogSCMListener.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogSCMListener.java
@@ -40,6 +40,9 @@ public class DatadogSCMListener extends SCMListener {
   public void onCheckout(Run<?, ?> build, SCM scm, FilePath workspace, TaskListener listener,
           File changelogFile, SCMRevisionState pollingBaseline) throws Exception {
 
+    if ( DatadogUtilities.isApiKeyNull() ) {
+      return;
+    }
     String jobName = build.getParent().getFullName();
     String normalizedJobName = DatadogUtilities.normalizeFullDisplayName(jobName);
     HashMap<String,String> tags = new HashMap<String,String>();

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogUtilities.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogUtilities.java
@@ -76,6 +76,16 @@ public class DatadogUtilities {
 
   /**
    *
+   * Check if apiKey is null
+   *
+   * @return boolean - apiKey is null
+   */
+  public static boolean isApiKeyNull() {
+    return Secret.toString(DatadogUtilities.getApiKey()).isEmpty();
+  }
+
+  /**
+   *
    * @return - The list of excluded jobs configured in the global configuration. Shortcut method.
    */
   public static String getBlacklist() {


### PR DESCRIPTION
- Only run if the Datadog API key is configured
- Use `Secret.toString()` to avoid NPE's when plugin is installed but no API key is configured.