### PR TITLE
Add a timeout to HTTP request connection and reads

### DIFF
--- a/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogHttpRequests.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogHttpRequests.java
@@ -55,6 +55,14 @@ public class DatadogHttpRequests {
       logger.fine("Using HttpURLConnection, without proxy");
     }
 
+    /* Timeout of 3 minutes for connecting and reading.
+     * this prevents this plugin from causing jobs to hang in case of
+     * flaky network or Datadog being down. Left intentionally long.
+     */
+    int timeoutMS = 3 * 60 * 1000;
+    conn.setConnectTimeout(timeoutMS);
+    conn.setReadTimeout(timeoutMS);
+
     return conn;
   }
 


### PR DESCRIPTION
This prevents job hangs when the connection to datadog is flaky. Currently set to 3 minutes