### PR TITLE
Add note about EU

### DIFF
--- a/src/main/resources/org/datadog/jenkins/plugins/datadog/DatadogBuildListener/help-targetMetricURL.html
+++ b/src/main/resources/org/datadog/jenkins/plugins/datadog/DatadogBuildListener/help-targetMetricURL.html
@@ -1,4 +1,4 @@
 <div>
     API URL which the plugin reports to. Defaults to <em>https://api.datadoghq.com/api/</em><br>
-    To submit metrics to an EU Datadog account, use: <em>https://api.datadoghq.eu/api</em>
+    To submit metrics to a Datadog EU site organization, use: <em>https://api.datadoghq.eu/api</em>
 </div>

--- a/src/main/resources/org/datadog/jenkins/plugins/datadog/DatadogBuildListener/help-targetMetricURL.html
+++ b/src/main/resources/org/datadog/jenkins/plugins/datadog/DatadogBuildListener/help-targetMetricURL.html
@@ -1,3 +1,4 @@
 <div>
-    API URL which the plugin reports to. Defaults to <em>https://api.datadoghq.com/api/</em>
+    API URL which the plugin reports to. Defaults to <em>https://api.datadoghq.com/api/</em><br>
+    To submit metrics to an EU Datadog account, use: <em>https://api.datadoghq.eu/api</em>
 </div>


### PR DESCRIPTION
The Advanced Target URL configuration option can easily allow users to be able to submit metrics to an EU Datadog account. 

This PR aims to make that a bit clearer. 

Example of what this looks like - https://cl.ly/45230bb597c0