### PR TITLE
Add support for pipeline tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,17 @@ From the global configuration page, at `Manage Jenkins -> Configure System`.
 
 From a job specific configuration page
 * Custom tags
-	* Added from a file in the job workspace (not compatible with Pipeline jobs), or
+	* Added from a file in the job workspace
+    * Added from a pipeline
 	* Added as text directly from the configuration page
+
+**Pipeline Tags Usage**
+
+```
+node {
+   step([$class: 'DatadogBuildStep', tags: 'tag1=value1 tag2=value2 tag3=value3'])
+}
+```
 
 ## Installation
 _This plugin requires [Jenkins 1.580.1](http://updates.jenkins-ci.org/download/war/1.580.1/jenkins.war) or newer._

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogBuildStep.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogBuildStep.java
@@ -1,0 +1,49 @@
+package org.datadog.jenkins.plugins.datadog;
+
+import hudson.Extension;
+import hudson.FilePath;
+import hudson.Launcher;
+import hudson.model.*;
+import hudson.tasks.*;
+import jenkins.tasks.SimpleBuildStep;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+import javax.annotation.Nonnull;
+import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class DatadogBuildStep extends Builder implements SimpleBuildStep {
+    public static Map<String,String> tagPool = new ConcurrentHashMap<>();
+    private final String tags;
+
+    @DataBoundConstructor
+    public DatadogBuildStep(String tags) {
+        this.tags = tags;
+    }
+
+    public String getTags() {
+        return tags;
+    }
+
+    @Override
+    public void perform(@Nonnull Run<?, ?> run, @Nonnull FilePath workspace, @Nonnull Launcher launcher,
+                        @Nonnull TaskListener listener) throws InterruptedException, IOException {
+        String jobName = run.getParent().getFullName();
+        tagPool.put(jobName, tags);
+    }
+
+    @Extension
+    public static final class DescriptorImpl extends BuildStepDescriptor<Builder> {
+        public DescriptorImpl() {
+        }
+
+        public boolean isApplicable(Class<? extends AbstractProject> jobType) {
+            return true;
+        }
+
+        public String getDisplayName() {
+            return "DataDog Tagging";
+        }
+    }
+}

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogUtilities.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogUtilities.java
@@ -24,26 +24,230 @@ import java.util.regex.Pattern;
 
 public class DatadogUtilities {
 
-    private static final Logger logger = Logger.getLogger(DatadogSCMListener.class.getName());
+  private static final Logger logger =  Logger.getLogger(DatadogSCMListener.class.getName());
+  /**
+   *
+   * @return - The descriptor for the Datadog plugin. In this case the global
+   *         - configuration.
+   */
+  public static DatadogBuildListener.DescriptorImpl getDatadogDescriptor() {
+    DatadogBuildListener.DescriptorImpl desc = (DatadogBuildListener.DescriptorImpl)Jenkins.getInstance().getDescriptorOrDie(DatadogBuildListener.class);
+    return desc;
+  }
 
-    /**
-     * Human-friendly OS name. Commons return values are windows, linux, mac, sunos, freebsd
-     *
-     * @return a String with a human-friendly OS name
-     */
-    public static String getOS() {
-        String out = System.getProperty("os.name");
-        String os = out.split(" ")[0];
-        return os.toLowerCase();
+  /**
+   *
+   * @return - The hostname configured in the global configuration. Shortcut method.
+   */
+  public static String getHostName()  {
+    return DatadogUtilities.getDatadogDescriptor().getHostname();
+  }
+
+  /**
+   * Set Hostname for global configuration.
+   *
+   * @param hostName - A string representing the hostname
+   */
+  public static void setHostName(String hostName)  {
+    DatadogUtilities.getDatadogDescriptor().setHostname(hostName);
+  }
+
+  /**
+   *
+   * @return - The api key configured in the global configuration. Shortcut method.
+   */
+  public static Secret getApiKey() {
+    return DatadogUtilities.getDatadogDescriptor().getApiKey();
+  }
+
+  /**
+   *
+   * Set ApiKey for global configuration.
+   *
+   * @param apiKey - A string representing an apiKey
+   */
+  public static void setApiKey(String apiKey) {
+    DatadogUtilities.getDatadogDescriptor().setApiKey(apiKey);
+  }
+
+  /**
+   *
+   * Check if apiKey is null
+   *
+   * @return boolean - apiKey is null
+   */
+  public static boolean isApiKeyNull() {
+    return Secret.toString(DatadogUtilities.getApiKey()).isEmpty();
+  }
+
+  /**
+   *
+   * @return - The list of excluded jobs configured in the global configuration. Shortcut method.
+   */
+  public static String getBlacklist() {
+    return DatadogUtilities.getDatadogDescriptor().getBlacklist();
+  }
+  /**
+   *
+   * @return - The list of included jobs configured in the global configuration. Shortcut method.
+   */
+  public static String getWhitelist() {
+    return DatadogUtilities.getDatadogDescriptor().getWhitelist();
+  }
+
+  /**
+   *
+   * @return - The list of included jobs configured in the global configuration. Shortcut method.
+   */
+  public static String getGlobalJobTags() {
+    return DatadogUtilities.getDatadogDescriptor().getGlobalJobTags();
+  }
+
+  /**
+   *
+   * @return - The target API URL
+   */
+  public static String getTargetMetricURL()  {
+    return DatadogUtilities.getDatadogDescriptor().getTargetMetricURL();
+  }
+
+  /**
+   * Checks if a jobName is blacklisted, whitelisted, or neither.
+   *
+   * @param jobName - A String containing the name of some job.
+   * @return a boolean to signify if the jobName is or is not blacklisted or whitelisted.
+   */
+  public static boolean isJobTracked(final String jobName) {
+    return !DatadogUtilities.isJobBlacklisted(jobName) && DatadogUtilities.isJobWhitelisted(jobName);
+  }
+
+  /**
+   * Retrieve the list of tags from the Config file if regex Jobs was checked
+   *  @param jobName - A string containing the name of some job
+   *  @return - A Map of values containing the key and value of each Datadog tag to apply to the metric/event
+   */
+  public static Map<String,String> getRegexJobTags(String jobName) {
+    Map<String,String> tags = new HashMap<String,String>();
+    final List<List<String>> globalTags = DatadogUtilities.regexJoblistStringtoList( DatadogUtilities.getGlobalJobTags() );
+
+    logger.fine(String.format("The list of Global Job Tags are: %s", globalTags));
+
+    // Each jobInfo is a list containing one regex, and a variable number of tags
+    for (List<String> jobInfo: globalTags) {
+
+      if(jobInfo.isEmpty()) {
+        continue;
+      }
+
+      Pattern p = Pattern.compile(jobInfo.get(0));
+      Matcher m = p.matcher(jobName);
+      if(m.matches()) {
+        for(int i = 1; i < jobInfo.size(); i++) {
+          String[] tagItem = jobInfo.get(i).split(":");
+          if(Character.toString(tagItem[1].charAt(0)).equals("$")) {
+            try {
+              tags.put(tagItem[0], m.group(Character.getNumericValue(tagItem[1].charAt(1))));
+            } catch(IndexOutOfBoundsException e) {
+              logger.fine(String.format("Specified a capture group that doesn't exist, not applying tag: %s Exception: %s", Arrays.toString(tagItem), e));
+            }
+          } else {
+            tags.put(tagItem[0], tagItem[1]);
+          }
+        }
+      }
+    }
+
+    return tags;
+  }
+
+  /**
+   * Checks if a jobName is blacklisted.
+   *
+   * @param jobName - A String containing the name of some job.
+   * @return a boolean to signify if the jobName is or is not blacklisted.
+   */
+  public static boolean isJobBlacklisted(final String jobName) {
+    final List<String> blacklist = DatadogUtilities.joblistStringtoList( DatadogUtilities.getBlacklist() );
+    return blacklist.contains(jobName.toLowerCase());
+  }
+
+  /**
+   * Checks if a jobName is whitelisted.
+   *
+   * @param jobName - A String containing the name of some job.
+   * @return a boolean to signify if the jobName is or is not whitelisted.
+   */
+  public static boolean isJobWhitelisted(final String jobName) {
+    final List<String> whitelist = DatadogUtilities.joblistStringtoList( DatadogUtilities.getWhitelist() );
+
+    // Check if the user config is using regexes
+    return whitelist.isEmpty() || whitelist.contains(jobName.toLowerCase());
+  }
+
+  /**
+   * Converts a blacklist/whitelist string into a String array.
+   *
+   * @param joblist - A String containing a set of job names.
+   * @return a String array representing the job names to be whitelisted/blacklisted. Returns
+   *         empty string if blacklist is null.
+   */
+  private static List<String> joblistStringtoList(final String joblist) {
+    List<String> jobs = new ArrayList<>();
+    if ( joblist != null ) {
+      for (String job: joblist.trim().split(",")) {
+          if (!job.isEmpty()) {
+              jobs.add(job.trim().toLowerCase());
+          }
+      }
     }
 
     /**
-     * @return - The descriptor for the Datadog plugin. In this case the global
-     * - configuration.
-     */
-    public static DatadogBuildListener.DescriptorImpl getDatadogDescriptor() {
-        return (DatadogBuildListener.DescriptorImpl) Jenkins.getInstance().
-                getDescriptorOrDie(DatadogBuildListener.class);
+   * Converts a blacklist/whitelist string into a String array.
+   * This is the implementation for when the Use Regex checkbox is enabled
+   *
+   * @param joblist - A String containing a set of job name regexes and tags.
+   * @return a String List representing the job names to be whitelisted/blacklisted and its associated tags.
+   *         Returns empty string if blacklist is null.
+   */
+  private static List<List<String>> regexJoblistStringtoList(final String joblist) {
+    List<List<String>> jobs = new ArrayList<>();
+    if ( joblist != null  && joblist.length() != 0) {
+      for (String job: joblist.split("\\r?\\n")) {
+        List<String> jobAndTags = new ArrayList<>();
+        for (String item: job.split(",")) {
+          if (!item.isEmpty()) {
+            jobAndTags.add(item);
+          }
+        }
+        jobs.add(jobAndTags);
+      }
+    }
+    return jobs;
+  }
+
+  /**
+   * This method parses the contents of the configured Datadog tags. If they are present.
+   * Takes the current build as a parameter. And returns the expanded tags and their
+   * values in a HashMap.
+   *
+   * Always returns a HashMap, that can be empty, if no tagging is configured.
+   *
+   * @param run - Current build
+   * @param listener - Current listener
+   * @return A {@link HashMap} containing the key,value pairs of tags. Never null.
+   * @throws IOException if an error occurs when reading from any objects
+   * @throws InterruptedException if an interrupt error occurs
+   */
+  @Nonnull
+  public static HashMap<String,String> parseTagList(Run run, TaskListener listener) throws IOException,
+          InterruptedException {
+    HashMap<String,String> map = new HashMap<String, String>();
+
+    DatadogJobProperty property = DatadogUtilities.retrieveProperty(run);
+
+    // If Null, nothing to retrieve
+    if( property == null ) {
+      return map;
     }
 
     /**
@@ -62,11 +266,39 @@ public class DatadogUtilities {
         DatadogUtilities.getDatadogDescriptor().setHostname(hostName);
     }
 
-    /**
-     * @return - The api key configured in the global configuration. Shortcut method.
-     */
-    public static Secret getApiKey() {
-        return DatadogUtilities.getDatadogDescriptor().getApiKey();
+    String jobName = run.getParent().getFullName();
+    if( DatadogBuildStep.tagPool.containsKey(jobName)) {
+      String tags = DatadogBuildStep.tagPool.get(jobName);
+      DatadogBuildStep.tagPool.remove(jobName);
+      for(String tag : tags.split(" ")) {
+        String[] expanded = run.getEnvironment(listener).expand(tag).split("=");
+        if( expanded.length > 1 ) {
+          map.put(expanded[0], expanded[1]);
+          logger.fine(String.format("Emitted tag %s:%s", expanded[0], expanded[1]));
+        } else {
+          logger.fine(String.format("Ignoring the tag %s. It is empty.", tag));
+        }
+      }
+    }
+
+    return map;
+  }
+
+  /**
+   * Builds extraTags if any are configured in the Job.
+   *
+   * @param run - Current build
+   * @param listener - Current listener
+   * @return A {@link HashMap} containing the key,value pairs of tags if any.
+   */
+  public static HashMap<String,String> buildExtraTags(Run run, TaskListener listener) {
+    HashMap<String,String> extraTags = new HashMap<String, String>();
+    try {
+      extraTags = DatadogUtilities.parseTagList(run, listener);
+    } catch (IOException ex) {
+      logger.severe(ex.getMessage());
+    } catch (InterruptedException ex) {
+      logger.severe(ex.getMessage());
     }
 
     /**
@@ -319,7 +551,7 @@ public class DatadogUtilities {
      * Getter function to return either the saved hostname global configuration,
      * or the hostname that is set in the Jenkins host itself. Returns null if no
      * valid hostname is found.
-     * 
+     *
      * Tries, in order:
      * Jenkins configuration
      * Jenkins hostname environment variable

--- a/src/main/resources/org/datadog/jenkins/plugins/datadog/DatadogBuildStep/config.jelly
+++ b/src/main/resources/org/datadog/jenkins/plugins/datadog/DatadogBuildStep/config.jelly
@@ -1,0 +1,6 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+    <f:entry title="Tags" field="tags">
+        <f:textbox/>
+    </f:entry>
+</j:jelly>

--- a/src/main/resources/org/datadog/jenkins/plugins/datadog/DatadogJobProperty/config.jelly
+++ b/src/main/resources/org/datadog/jenkins/plugins/datadog/DatadogJobProperty/config.jelly
@@ -3,7 +3,7 @@
     <f:section title="Datadog Tagging">
         <f:optionalBlock name="enableFile" checked="${!instance.isTagFileEmpty()}" title="Add tags from file in workspace" inline="true">
             <f:entry title="File" field="tagFile">
-                <f:textbox/>
+                <f:textbox value="datadog.tags"/>
             </f:entry>
             <f:entry title="Send extra event after each successful checkout" field="emitOnCheckout"
 description="Note: Tags set this way, in the workspace, won't appear in started events.

--- a/src/test/java/org/datadog/jenkins/plugins/datadog/DatadogBuildStepTest.java
+++ b/src/test/java/org/datadog/jenkins/plugins/datadog/DatadogBuildStepTest.java
@@ -51,24 +51,23 @@ public class DatadogBuildStepTest {
 
         String pipelineTags = "myTag1=val1 myTag2=val2 myTag3=val3";
         String jobName = run.getParent().getFullName();
-        
+
         String badPipelineTags = "tag1=val1, tag2=val2, tag3=val3";
         String fakeJobName = "parent/fake-job";
 
         datadogBuildStep = spy(new DatadogBuildStep(pipelineTags));
-
 		datadogBuildStep.perform(run, workspace, launcher, taskListener);
 
 		Map<String,String> expectedTagPool = new ConcurrentHashMap<>();
 		expectedTagPool.put(jobName, pipelineTags);
-		
+
 		Map<String,String> notExpectedTagPool = new ConcurrentHashMap<>();
 		notExpectedTagPool.put(fakeJobName, badPipelineTags);
 
 		assertThat(datadogBuildStep.tagPool, is(expectedTagPool));
 		assertThat(datadogBuildStep.tagPool, IsMapContaining.hasKey(jobName));
 		assertThat(datadogBuildStep.tagPool, IsMapContaining.hasValue(pipelineTags));
-		
+
 		assertThat(datadogBuildStep.tagPool, not(is(notExpectedTagPool)));
 		assertThat(datadogBuildStep.tagPool, not(IsMapContaining.hasValue(badPipelineTags)));
 		assertThat(datadogBuildStep.tagPool, not(IsMapContaining.hasKey(fakeJobName)));

--- a/src/test/java/org/datadog/jenkins/plugins/datadog/DatadogBuildStepTest.java
+++ b/src/test/java/org/datadog/jenkins/plugins/datadog/DatadogBuildStepTest.java
@@ -1,0 +1,97 @@
+package org.datadog.jenkins.plugins.datadog;
+
+import static org.junit.Assert.*;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import hudson.FilePath;
+import hudson.Launcher;
+import hudson.model.ItemGroup;
+import hudson.model.Job;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import jenkins.model.Jenkins;
+import static org.mockito.Mockito.*;
+
+import java.io.File;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.hamcrest.collection.IsMapContaining;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({Jenkins.class})
+public class DatadogBuildStepTest {
+	@Mock
+	private Jenkins jenkins;
+
+	private DatadogBuildStep datadogBuildStep;
+
+	@Before
+	public void setUp() throws Exception {
+        PowerMockito.mockStatic(Jenkins.class);
+        PowerMockito.when(Jenkins.getInstance()).thenReturn(jenkins);
+	}
+
+	@Test
+	public void perform() throws Exception {
+		Run run = run();
+		FilePath workspace = new FilePath(new File("/path/to/workspace"));
+		Launcher launcher = mock(Launcher.class);
+        TaskListener taskListener = mock(TaskListener.class);
+
+        String pipelineTags = "myTag1=val1 myTag2=val2 myTag3=val3";
+        String jobName = run.getParent().getFullName();
+        
+        String badPipelineTags = "tag1=val1, tag2=val2, tag3=val3";
+        String fakeJobName = "parent/fake-job";
+
+        datadogBuildStep = spy(new DatadogBuildStep(pipelineTags));
+
+		datadogBuildStep.perform(run, workspace, launcher, taskListener);
+
+		Map<String,String> expectedTagPool = new ConcurrentHashMap<>();
+		expectedTagPool.put(jobName, pipelineTags);
+		
+		Map<String,String> notExpectedTagPool = new ConcurrentHashMap<>();
+		notExpectedTagPool.put(fakeJobName, badPipelineTags);
+
+		assertThat(datadogBuildStep.tagPool, is(expectedTagPool));
+		assertThat(datadogBuildStep.tagPool, IsMapContaining.hasKey(jobName));
+		assertThat(datadogBuildStep.tagPool, IsMapContaining.hasValue(pipelineTags));
+		
+		assertThat(datadogBuildStep.tagPool, not(is(notExpectedTagPool)));
+		assertThat(datadogBuildStep.tagPool, not(IsMapContaining.hasValue(badPipelineTags)));
+		assertThat(datadogBuildStep.tagPool, not(IsMapContaining.hasKey(fakeJobName)));
+
+	}
+
+	private Run run() throws Exception {
+        Run run = mock(Run.class);
+
+        Job job = job();
+        when(run.getParent()).thenReturn(job);
+
+        return run;
+    }
+
+    private Job job() {
+        ItemGroup<?> parent = mock(ItemGroup.class);
+        when(parent.getFullName()).thenReturn("parent");
+
+        Job job = mock(Job.class);
+        when(job.getName()).thenReturn("test-job");
+        when(job.getParent()).thenReturn(parent);
+
+        return job;
+    }
+}


### PR DESCRIPTION
Adds changes from https://github.com/DataDog/jenkins-datadog-plugin/pull/144 (thanks [caryyu](https://github.com/caryyu)!) to support custom tagging from the Jenkins pipeline (jenkinsfile).

- Declare and Assume a default tag file "datadog.tags" in the workspace - Not working for pipeline
- Support the pipeline of Jenkins

Also adds test for the new DatadogBuildStep. 