### PR TITLE
Add support for pipeline tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ target/*
 nb-configuration.xml
 .idea
 *.iml
+.factorypath

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ From the global configuration page, at `Manage Jenkins -> Configure System`.
 From a job specific configuration page
 * Custom tags
 	* Added from a file in the job workspace
-    * Added from a pipeline
+	* Added from a pipeline
 	* Added as text directly from the configuration page
 
 **Pipeline Tags Usage**

--- a/README.md
+++ b/README.md
@@ -50,8 +50,17 @@ From the global configuration page, at `Manage Jenkins -> Configure System`.
 
 From a job specific configuration page
 * Custom tags
-	* Added from a file in the job workspace (not compatible with Pipeline jobs), or
+	* Added from a file in the job workspace
+    * Added from a pipeline
 	* Added as text directly from the configuration page
+
+**Pipeline Tags Usage**
+
+```
+node {
+   step([$class: 'DatadogBuildStep', tags: 'tag1=value1 tag2=value2 tag3=value3'])
+}
+```
 
 ## Installation
 _This plugin requires [Jenkins 1.580.1](http://updates.jenkins-ci.org/download/war/1.580.1/jenkins.war) or newer._

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogBuildStep.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogBuildStep.java
@@ -1,0 +1,49 @@
+package org.datadog.jenkins.plugins.datadog;
+
+import hudson.Extension;
+import hudson.FilePath;
+import hudson.Launcher;
+import hudson.model.*;
+import hudson.tasks.*;
+import jenkins.tasks.SimpleBuildStep;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+import javax.annotation.Nonnull;
+import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class DatadogBuildStep extends Builder implements SimpleBuildStep {
+    public static Map<String,String> tagPool = new ConcurrentHashMap<>();
+    private final String tags;
+
+    @DataBoundConstructor
+    public DatadogBuildStep(String tags) {
+        this.tags = tags;
+    }
+
+    public String getTags() {
+        return tags;
+    }
+
+    @Override
+    public void perform(@Nonnull Run<?, ?> run, @Nonnull FilePath workspace, @Nonnull Launcher launcher,
+                        @Nonnull TaskListener listener) throws InterruptedException, IOException {
+        String jobName = run.getParent().getFullName();
+        tagPool.put(jobName, tags);
+    }
+
+    @Extension
+    public static final class DescriptorImpl extends BuildStepDescriptor<Builder> {
+        public DescriptorImpl() {
+        }
+
+        public boolean isApplicable(Class<? extends AbstractProject> jobType) {
+            return true;
+        }
+
+        public String getDisplayName() {
+            return "DataDog Tagging";
+        }
+    }
+}

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogUtilities.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogUtilities.java
@@ -319,7 +319,7 @@ public class DatadogUtilities {
      * Getter function to return either the saved hostname global configuration,
      * or the hostname that is set in the Jenkins host itself. Returns null if no
      * valid hostname is found.
-     * 
+     *
      * Tries, in order:
      * Jenkins configuration
      * Jenkins hostname environment variable

--- a/src/main/resources/org/datadog/jenkins/plugins/datadog/DatadogBuildStep/config.jelly
+++ b/src/main/resources/org/datadog/jenkins/plugins/datadog/DatadogBuildStep/config.jelly
@@ -1,0 +1,6 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+    <f:entry title="Tags" field="tags">
+        <f:textbox/>
+    </f:entry>
+</j:jelly>

--- a/src/main/resources/org/datadog/jenkins/plugins/datadog/DatadogJobProperty/config.jelly
+++ b/src/main/resources/org/datadog/jenkins/plugins/datadog/DatadogJobProperty/config.jelly
@@ -3,7 +3,7 @@
     <f:section title="Datadog Tagging">
         <f:optionalBlock name="enableFile" checked="${!instance.isTagFileEmpty()}" title="Add tags from file in workspace" inline="true">
             <f:entry title="File" field="tagFile">
-                <f:textbox/>
+                <f:textbox value="datadog.tags"/>
             </f:entry>
             <f:entry title="Send extra event after each successful checkout" field="emitOnCheckout"
 description="Note: Tags set this way, in the workspace, won't appear in started events.

--- a/src/test/java/org/datadog/jenkins/plugins/datadog/DatadogBuildStepTest.java
+++ b/src/test/java/org/datadog/jenkins/plugins/datadog/DatadogBuildStepTest.java
@@ -1,0 +1,96 @@
+package org.datadog.jenkins.plugins.datadog;
+
+import static org.junit.Assert.*;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import hudson.FilePath;
+import hudson.Launcher;
+import hudson.model.ItemGroup;
+import hudson.model.Job;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import jenkins.model.Jenkins;
+import static org.mockito.Mockito.*;
+
+import java.io.File;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.hamcrest.collection.IsMapContaining;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({Jenkins.class})
+public class DatadogBuildStepTest {
+	@Mock
+	private Jenkins jenkins;
+
+	private DatadogBuildStep datadogBuildStep;
+
+	@Before
+	public void setUp() throws Exception {
+        PowerMockito.mockStatic(Jenkins.class);
+        PowerMockito.when(Jenkins.getInstance()).thenReturn(jenkins);
+	}
+
+	@Test
+	public void perform() throws Exception {
+		Run run = run();
+		FilePath workspace = new FilePath(new File("/path/to/workspace"));
+		Launcher launcher = mock(Launcher.class);
+        TaskListener taskListener = mock(TaskListener.class);
+
+        String pipelineTags = "myTag1=val1 myTag2=val2 myTag3=val3";
+        String jobName = run.getParent().getFullName();
+
+        String badPipelineTags = "tag1=val1, tag2=val2, tag3=val3";
+        String fakeJobName = "parent/fake-job";
+
+        datadogBuildStep = spy(new DatadogBuildStep(pipelineTags));
+		datadogBuildStep.perform(run, workspace, launcher, taskListener);
+
+		Map<String,String> expectedTagPool = new ConcurrentHashMap<>();
+		expectedTagPool.put(jobName, pipelineTags);
+
+		Map<String,String> notExpectedTagPool = new ConcurrentHashMap<>();
+		notExpectedTagPool.put(fakeJobName, badPipelineTags);
+
+		assertThat(datadogBuildStep.tagPool, is(expectedTagPool));
+		assertThat(datadogBuildStep.tagPool, IsMapContaining.hasKey(jobName));
+		assertThat(datadogBuildStep.tagPool, IsMapContaining.hasValue(pipelineTags));
+
+		assertThat(datadogBuildStep.tagPool, not(is(notExpectedTagPool)));
+		assertThat(datadogBuildStep.tagPool, not(IsMapContaining.hasValue(badPipelineTags)));
+		assertThat(datadogBuildStep.tagPool, not(IsMapContaining.hasKey(fakeJobName)));
+
+	}
+
+	private Run run() throws Exception {
+        Run run = mock(Run.class);
+
+        Job job = job();
+        when(run.getParent()).thenReturn(job);
+
+        return run;
+    }
+
+    private Job job() {
+        ItemGroup<?> parent = mock(ItemGroup.class);
+        when(parent.getFullName()).thenReturn("parent");
+
+        Job job = mock(Job.class);
+        when(job.getName()).thenReturn("test-job");
+        when(job.getParent()).thenReturn(parent);
+
+        return job;
+    }
+}


### PR DESCRIPTION
Adds changes from https://github.com/DataDog/jenkins-datadog-plugin/pull/144 (thanks [caryyu](https://github.com/caryyu)!) to support custom tagging from the Jenkins pipeline (Jenkinsfile).

- Declare and Assume a default tag file "datadog.tags" in the workspace - Not working for pipeline
- Support the pipeline of Jenkins
- Also adds test for the new DatadogBuildStep