### PR TITLE
add more metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ List of events:
 |--------------------------|---------------------------------------------------------------|
 | jenkins.executor.count   | Executor count                                                |
 | jenkins.executor.free    | Number of unused executor                                     |
-| jenkins.executor.in-use  | Number of idle executor                                       |
+| jenkins.executor.in_use  | Number of idle executor                                       |
 | jenkins.job.completed    | Rate of completed jobs                                        |
 | jenkins.job.cycletime    | Build Cycle Time                                              |
 | jenkins.job.duration     | Build duration (in seconds)                                   |
@@ -52,9 +52,9 @@ All events, metrics, and service checks include the following tags, if they are 
 * `node`
 
 `jenkins.executor.*` metrics have the following additional tags:
-* `node-hostname`
-* `node-name`
-* `node-label`
+* `node_hostname`
+* `node_name`
+* `node_label`
 
 
 ## Customization

--- a/README.md
+++ b/README.md
@@ -16,16 +16,28 @@ List of events:
 
 | Metric Name              | Description                                                   |
 |--------------------------|---------------------------------------------------------------|
+| jenkins.executor.count   | Executor count                                                |
+| jenkins.executor.free    | Number of unused executor                                     |
+| jenkins.executor.in-use  | Number of idle executor                                       |
 | jenkins.job.completed    | Rate of completed jobs                                        |
-| jenkins.job.started      | Rate of started jobs                                          |
-| jenkins.job.leadtime     | Lead Time                                                     |
-| jenkins.job.cycletime    | Cycle Time                                                    |
-| jenkins.job.mttr         | MTTR: time between last failed job and current successful job |
-| jenkins.job.feedbacktime | Feedback time from code commit to job failure                 |
-| jenkins.job.mtbf         | MTBF, time between last successful job and current failed job |
+| jenkins.job.cycletime    | Build Cycle Time                                              |
 | jenkins.job.duration     | Build duration (in seconds)                                   |
+| jenkins.job.feedbacktime | Feedback time from code commit to job failure                 |
+| jenkins.job.leadtime     | Build Lead Time                                               |
+| jenkins.job.mtbf         | MTBF, time between last successful job and current failed job |
+| jenkins.job.mttr         | MTTR: time between last failed job and current successful job |
+| jenkins.job.started      | Rate of started jobs                                          |
 | jenkins.job.waiting      | Time spent waiting for job to run (in milliseconds)           |
+| jenkins.node.count       | Total number of node                                          |
+| jenkins.node.offline     | Offline nodes count                                           |
+| jenkins.node.online      | Online nodes count                                            |
+| jenkins.plugin.count     | Plugins count                                                 |
+| jenkins.project.count    | Project count                                                 |
 | jenkins.queue.size       | Queue Size                                                    |
+| jenkins.queue.buildable  | Number of Buildable item in Queue                             |
+| jenkins.queue.pending    | Number of Pending item in Queue                               |
+| jenkins.queue.stuck      | Number of Stuck item in Queue                                 |
+| jenkins.queue.blocked    | Number of Blocked item in Queue                               |
 | jenkins.scm.checkout     | Rate of SCM checkouts                                         |
 
 
@@ -38,6 +50,11 @@ All events, metrics, and service checks include the following tags, if they are 
 * (Git Branch, SVN revision or CVS branch) `branch` 
   * Git Branch available when using the [Git Plugin](https://wiki.jenkins.io/display/JENKINS/Git+Plugin)
 * `node`
+
+`jenkins.executor.*` metrics have the following additional tags:
+* `node-hostname`
+* `node-name`
+* `node-label`
 
 
 ## Customization

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/publishers/DatadogJenkinsPublisher.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/publishers/DatadogJenkinsPublisher.java
@@ -1,0 +1,59 @@
+package org.datadog.jenkins.plugins.datadog.publishers;
+
+import hudson.Extension;
+import hudson.model.PeriodicWork;
+import hudson.model.Project;
+import jenkins.model.Jenkins;
+import org.datadog.jenkins.plugins.datadog.DatadogClient;
+import org.datadog.jenkins.plugins.datadog.DatadogUtilities;
+
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Logger;
+
+/**
+ * This class registers a {@link PeriodicWork} with Jenkins to run periodically in order to enable
+ * us to compute metrics related to Jenkins level metrics.
+ */
+@Extension
+public class DatadogJenkinsPublisher extends PeriodicWork {
+
+    private static final Logger logger = Logger.getLogger(DatadogJenkinsPublisher.class.getName());
+
+    private static final long RECURRENCE_PERIOD = TimeUnit.MINUTES.toMillis(1);
+
+    @Override
+    public long getRecurrencePeriod() {
+        return RECURRENCE_PERIOD;
+    }
+
+    @Override
+    protected void doRun() throws Exception {
+        try {
+            logger.fine("doRun called: Computing Node metrics");
+
+            // Get Datadog Client Instance
+            DatadogClient client = DatadogUtilities.getDatadogClient();
+            String hostname = DatadogUtilities.getHostname("null");
+
+            long projectCount = 0;
+            try {
+                projectCount = Jenkins.getInstance().getAllItems(Project.class).size();
+            } catch (NullPointerException e){
+                logger.fine("Could not retrieve projects");
+            }
+            long pluginCount = 0;
+            try {
+                pluginCount = Jenkins.getInstance().pluginManager.getPlugins().size();
+            } catch (NullPointerException e){
+                logger.fine("Could not retrieve plugins");
+            }
+            client.gauge("jenkins.project.count", projectCount, hostname, null);
+            client.gauge("jenkins.plugin.count", pluginCount, hostname, null);
+
+        } catch (Exception e) {
+            logger.warning("Unexpected exception occurred - " + e.getMessage());
+        }
+
+    }
+
+}

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/publishers/DatadogJenkinsPublisher.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/publishers/DatadogJenkinsPublisher.java
@@ -29,7 +29,7 @@ public class DatadogJenkinsPublisher extends PeriodicWork {
     @Override
     protected void doRun() throws Exception {
         try {
-            logger.fine("doRun called: Computing Node metrics");
+            logger.fine("doRun called: Computing Jenkins metrics");
 
             // Get Datadog Client Instance
             DatadogClient client = DatadogUtilities.getDatadogClient();

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/publishers/DatadogNodePublisher.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/publishers/DatadogNodePublisher.java
@@ -68,17 +68,17 @@ public class DatadogNodePublisher extends PeriodicWork {
                     nodeName = computer.getName();
                 }
                 JSONArray tags = new JSONArray();
-                tags.add("node-name:" + nodeName);
+                tags.add("node_name:" + nodeName);
                 if(nodeHostname != null){
-                    tags.add("node-hostname:" + nodeHostname);
+                    tags.add("node_hostname:" + nodeHostname);
                 }
                 if(labels != null){
                     for (LabelAtom label: labels){
-                        tags.add("node-label:" + label.getName());
+                        tags.add("node_label:" + label.getName());
                     }
                 }
                 client.gauge("jenkins.executor.count", executorCount, hostname, tags);
-                client.gauge("jenkins.executor.in-use", inUse, hostname, tags);
+                client.gauge("jenkins.executor.in_use", inUse, hostname, tags);
                 client.gauge("jenkins.executor.free", free, hostname, tags);
             }
 

--- a/src/main/java/org/datadog/jenkins/plugins/datadog/publishers/DatadogNodePublisher.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/publishers/DatadogNodePublisher.java
@@ -1,0 +1,95 @@
+package org.datadog.jenkins.plugins.datadog.publishers;
+
+import hudson.Extension;
+import hudson.model.Computer;
+import hudson.model.PeriodicWork;
+import hudson.model.labels.LabelAtom;
+import jenkins.model.Jenkins;
+import net.sf.json.JSONArray;
+import org.datadog.jenkins.plugins.datadog.DatadogClient;
+import org.datadog.jenkins.plugins.datadog.DatadogUtilities;
+
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Logger;
+
+/**
+ * This class registers a {@link PeriodicWork} with Jenkins to run periodically in order to enable
+ * us to compute metrics related to nodes and executors.
+ */
+@Extension
+public class DatadogNodePublisher extends PeriodicWork {
+
+    private static final Logger logger = Logger.getLogger(DatadogNodePublisher.class.getName());
+
+    private static final long RECURRENCE_PERIOD = TimeUnit.MINUTES.toMillis(1);
+
+    @Override
+    public long getRecurrencePeriod() {
+        return RECURRENCE_PERIOD;
+    }
+
+    @Override
+    protected void doRun() throws Exception {
+        try {
+            logger.fine("doRun called: Computing Node metrics");
+
+            // Get Datadog Client Instance
+            DatadogClient client = DatadogUtilities.getDatadogClient();
+            String hostname = DatadogUtilities.getHostname("null");
+
+            long nodeCount = 0;
+            long nodeOffline = 0;
+            long nodeOnline = 0;
+            Computer[] computers = Jenkins.getInstance().getComputers();
+            for (Computer computer : computers) {
+                nodeCount++;
+                if (computer.isOffline()) {
+                    nodeOffline++;
+                }
+                if (computer.isOnline()) {
+                    nodeOnline++;
+                }
+
+                int executorCount = computer.countExecutors();
+                int inUse = computer.countBusy();
+                int free = computer.countIdle();
+                Set<LabelAtom> labels = null;
+                try {
+                    labels = computer.getNode().getAssignedLabels();
+                } catch (NullPointerException e){
+                    logger.fine("Could not retrieve labels");
+                }
+                String nodeHostname = computer.getHostName();
+                String nodeName;
+                if (computer instanceof Jenkins.MasterComputer) {
+                    nodeName =  "master";
+                } else {
+                    nodeName = computer.getName();
+                }
+                JSONArray tags = new JSONArray();
+                tags.add("node-name:" + nodeName);
+                if(nodeHostname != null){
+                    tags.add("node-hostname:" + nodeHostname);
+                }
+                if(labels != null){
+                    for (LabelAtom label: labels){
+                        tags.add("node-label:" + label.getName());
+                    }
+                }
+                client.gauge("jenkins.executor.count", executorCount, hostname, tags);
+                client.gauge("jenkins.executor.in-use", inUse, hostname, tags);
+                client.gauge("jenkins.executor.free", free, hostname, tags);
+            }
+
+            client.gauge("jenkins.node.count", nodeCount, hostname, null);
+            client.gauge("jenkins.node.offline", nodeOffline, hostname, null);
+            client.gauge("jenkins.node.online", nodeOnline, hostname, null);
+
+        } catch (Exception e) {
+            logger.warning("Unexpected exception occurred - " + e.getMessage());
+        }
+
+    }
+
+}


### PR DESCRIPTION
- Fixes https://github.com/DataDog/jenkins-datadog-plugin/issues/91
- Fixes https://github.com/DataDog/jenkins-datadog-plugin/issues/2
  - Note that Metrics from the Host should be retrieved using the Datadog agent (with or without a JMX Fetch Datadog Integration)
- Fixes https://github.com/DataDog/jenkins-datadog-plugin/issues/1

Added the following metrics:
- `jenkins.project.count`
- `jenkins.plugin.count`
- `jenkins.executor.count`
- `jenkins.executor.in-use`
- `jenkins.executor.free`
- `jenkins.node.count`
- `jenkins.node.offline`
- `jenkins.node.online`
- `jenkins.queue.buildable`
- `jenkins.queue.pending`
- `jenkins.queue.stuck`
- `jenkins.queue.blocked`
