### PR TITLE
Fixes potential null pointers due to empty run job properties.

### DIFF
--- a/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogUtilities.java
+++ b/src/main/java/org/datadog/jenkins/plugins/datadog/DatadogUtilities.java
@@ -64,10 +64,15 @@ public class DatadogUtilities {
 
     /**
      * @param r - Current build.
-     * @return - The configured {@link DatadogJobProperty}. Null if not there
+     * @return - The configured {@link DatadogJobProperty}. Default object with empty properties if not there
      */
     public static DatadogJobProperty getDatadogJobProperties(@Nonnull Run r) {
-        return (DatadogJobProperty) r.getParent().getProperty(DatadogJobProperty.class);
+        DatadogJobProperty datadogJobProperty = (DatadogJobProperty) r.getParent().getProperty(DatadogJobProperty.class);
+        if (datadogJobProperty != null) {
+            return datadogJobProperty;
+        } else {
+            return new DatadogJobProperty();
+        }
     }
 
     /**


### PR DESCRIPTION
Relates to issue 196.

### Requirements for Contributing to this repository

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must only fix one issue at the time.
* The pull request must update the test suite to demonstrate the changed functionality.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. For more details, please see [CONTRIBUTING](/CONTRIBUTING.md). 

### What does this PR do?

Modifies the utility function `getDatadogJobProperties` so that it does not return null, as the value returned from this function is dereferenced later on.

What inspired you to submit this pull request?
Fixes issue described in #196 .

### Description of the Change

Modifies the utility function `getDatadogJobProperties` so that it does not return null, as the value returned from this function is dereferenced later on. The default values on DatadogJobProperty initialization are sane, so there is no harm in using a new object instead.

### Alternate Designs

A null object pattern could also be used if deemed worth it, in order to avoid meaningless instantiations and decouple defaults from the on-purpose empty objects like this.

### Possible Drawbacks

Couples the default values with the empty object logic. If the defaults are sane, I don't find this to be an issue though.

### Verification Process

<!--

What process did you follow to verify that your change has the desired effects?

Rerun the same jenkins jobs that were previously failing to produce events on the datadog website. Now the events are all shown as expected.

### Additional Notes

<!-- Anything else we should know when reviewing? -->

### Release Notes

<!--

If the PR title is not enough to describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be added in release notes.

For example, you can provide additionnal notes about feature deprecation or backward incompatible changes.

-->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bug fix MUST have appropriate tests (unit, integration, etc...)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.

